### PR TITLE
fix: resolve broken "Get Started Button" in pricing section

### DIFF
--- a/public/js/landing-auth.js
+++ b/public/js/landing-auth.js
@@ -95,6 +95,7 @@ function updateButtonsForAuthenticatedUser() {
     const heroStartBtn = document.getElementById('heroStartBtn');
     const mobileLoginBtn = document.getElementById('mobileLoginBtn');
     const mobileGetStartedBtn = document.getElementById('mobileGetStartedBtn');
+    const pricingGetStartedBtn = document.getElementById('pricingGetStartedBtn');
 
     // Desktop: Show only one button
     if (loginBtn) {
@@ -119,6 +120,11 @@ function updateButtonsForAuthenticatedUser() {
     if (mobileGetStartedBtn) {
         mobileGetStartedBtn.style.display = 'none';
     }
+
+    // Pricing section: Change button text if signed in
+    if (pricingGetStartedBtn) {
+        pricingGetStartedBtn.textContent = 'Go to Dashboard';
+    }
 }
 
 // Add event listeners when DOM is ready
@@ -134,12 +140,16 @@ document.addEventListener('DOMContentLoaded', () => {
     const mobileLoginBtn = document.getElementById('mobileLoginBtn');
     const mobileGetStartedBtn = document.getElementById('mobileGetStartedBtn');
     
+    // Pricing button
+    const pricingGetStartedBtn = document.getElementById('pricingGetStartedBtn');
+    
     console.log('Buttons found:', {
         loginBtn: !!loginBtn,
         getStartedBtn: !!getStartedBtn,
         heroStartBtn: !!heroStartBtn,
         mobileLoginBtn: !!mobileLoginBtn,
-        mobileGetStartedBtn: !!mobileGetStartedBtn
+        mobileGetStartedBtn: !!mobileGetStartedBtn,
+        pricingGetStartedBtn: !!pricingGetStartedBtn
     });
     
     // Attach click handlers to all buttons
@@ -186,6 +196,13 @@ document.addEventListener('DOMContentLoaded', () => {
                 mobileMenu.classList.add('translate-x-full');
             }
             // Then handle sign in
+            handleSmartSignIn();
+        });
+    }
+    
+    if (pricingGetStartedBtn) {
+        pricingGetStartedBtn.addEventListener('click', () => {
+            console.log('Pricing Get Started button clicked');
             handleSmartSignIn();
         });
     }

--- a/public/landing.html
+++ b/public/landing.html
@@ -282,7 +282,7 @@
                         </div>
                         <p class="text-gray-400 mb-8">Access to all features, for everyone.</p>
                         
-                        <a href="/signup" class="block w-full py-4 text-center bg-white text-black font-semibold rounded-xl hover:bg-gray-200 transition-colors mb-8">Get Started Now</a>
+                        <button id="pricingGetStartedBtn" class="block w-full py-4 text-center bg-white text-black font-semibold rounded-xl hover:bg-gray-200 transition-colors mb-8">Get Started Now</button>
                         
                         <div class="space-y-4">
                             <div class="flex items-center gap-3">


### PR DESCRIPTION
## Description
Earlier, the broken "Get Started Now" button was linked to a non-existent '/signup' route, causing a 404 error.

Since, we are using the Firebase Authentication via popup, I have updated the button to hook into the existing `handleSmartSignIn()` authentication flow used by the rest of the landing page.

## Changes Made
- **`public/landing.html`**: Converted the broken `<a>` tag into a `<button>` element and assigned it the ID `pricingGetStartedBtn`.
- **`public/js/landing-auth.js`**: 
  - Added an event listener to `pricingGetStartedBtn` to trigger `handleSmartSignIn()`.
  - Updated `updateButtonsForAuthenticatedUser()` to dynamically change the button text to "Go to Dashboard" if an active user session is detected.
  
## Testing
- Verified that clicking the button now successfully triggers the Google Sign-In popup.
- Verified that if a user is already signed in, the button correctly displays "Go to Dashboard" and successfully redirects to `/home`.