### PR TITLE
fix: resolve Three.js 404 CDN error causing dashboard blank screen

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1486,7 +1486,7 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
     <script src="https://unpkg.com/qr-code-styling@1.6.0-rc.1/lib/qr-code-styling.js"></script>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://unpkg.com/three@0.161.0/build/three.min.js"></script>
+    <script src="https://unpkg.com/three@0.152.2/build/three.min.js"></script>
     <script src="https://unpkg.com/globe.gl@2.31.0/dist/globe.gl.min.js"></script>
     
     <!-- App Scripts -->


### PR DESCRIPTION
## 🐛 Issue
Fixes #23 

The dashboard at `/home` was hanging on a blank screen due to a 404 
error when loading `three.min.js` from Unpkg.

## 🔍 Root Cause
`public/index.html` was loading Three.js from:
`https://unpkg.com/three@0.161.0/build/three.min.js`

Starting from Three.js v0.160+, the `three.min.js` UMD build was 
**removed** from the official package — only ES module builds are 
shipped now. This caused a 404, which in turn caused `globe.js` to 
crash and the dashboard to render a blank screen.

## ✅ Fix
Downgraded the Three.js CDN URL to a stable version that still ships 
`three.min.js`:

```diff
- <script src="https://unpkg.com/three@0.161.0/build/three.min.js"></script>
+ <script src="https://unpkg.com/three@0.152.2/build/three.min.js"></script>