### PR TITLE
fix: style mobile hamburger menu drawer on landing page

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -502,9 +502,23 @@ body {
 }
 
 .landing-mobile-menu {
+    position: fixed;
+    inset: 0;
+    z-index: 40;
+    display: flex;
+    flex-direction: column;
+    background: rgba(0, 0, 0, 0.95);
+    -webkit-backdrop-filter: blur(24px);
+    backdrop-filter: blur(24px);
     padding: max(5rem, env(safe-area-inset-top)) 1.5rem max(2rem, env(safe-area-inset-bottom));
     align-items: stretch;
     gap: 1.75rem;
+    transform: translateX(100%);
+    transition: transform 0.3s ease;
+}
+
+.landing-mobile-menu.open {
+    transform: translateX(0);
 }
 
 .landing-mobile-menu-header {
@@ -537,6 +551,14 @@ body {
     font-size: clamp(1.375rem, 4vw, 1.75rem);
     line-height: 1.2;
     letter-spacing: -0.02em;
+    color: rgba(255, 255, 255, 0.6);
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+
+.landing-mobile-link:hover,
+.landing-mobile-link:focus {
+    color: #ffffff;
 }
 
 .landing-mobile-menu-actions {

--- a/public/js/landing-auth.js
+++ b/public/js/landing-auth.js
@@ -180,7 +180,7 @@ document.addEventListener('DOMContentLoaded', () => {
             // Close mobile menu first
             const mobileMenu = document.getElementById('mobileMenu');
             if (mobileMenu) {
-                mobileMenu.classList.add('translate-x-full');
+                mobileMenu.classList.remove('open');
             }
             // Then handle sign in
             handleSmartSignIn();
@@ -193,7 +193,7 @@ document.addEventListener('DOMContentLoaded', () => {
             // Close mobile menu first
             const mobileMenu = document.getElementById('mobileMenu');
             if (mobileMenu) {
-                mobileMenu.classList.add('translate-x-full');
+                mobileMenu.classList.remove('open');
             }
             // Then handle sign in
             handleSmartSignIn();

--- a/public/js/landing.js
+++ b/public/js/landing.js
@@ -53,7 +53,7 @@ function initMobileMenu() {
     const toggle = document.getElementById('mobileMenuToggle');
     const menu = document.getElementById('mobileMenu');
     const closeButton = document.getElementById('mobileMenuClose');
-    const links = document.querySelectorAll('.mobile-link');
+    const links = document.querySelectorAll('.landing-mobile-link');
     
     if (!toggle || !menu) return;
 
@@ -70,7 +70,7 @@ function initMobileMenu() {
         if (!isOpen) return;
 
         isOpen = false;
-        menu.classList.add('translate-x-full');
+        menu.classList.remove('open');
         document.body.style.overflow = '';
         syncMenuState(false);
 
@@ -85,10 +85,10 @@ function initMobileMenu() {
         if (!isOpen) {
             previousFocus = document.activeElement;
             isOpen = true;
-            menu.classList.remove('translate-x-full');
+            menu.classList.add('open');
             document.body.style.overflow = 'hidden';
             syncMenuState(true);
-            const firstFocusable = menu.querySelector('.mobile-link, button, [href], [tabindex]:not([tabindex="-1"])');
+            const firstFocusable = menu.querySelector('a, button, [href], [tabindex]:not([tabindex="-1"])');
             if (firstFocusable) {
                 firstFocusable.focus();
             }

--- a/public/landing.html
+++ b/public/landing.html
@@ -84,16 +84,22 @@
     </nav>
 
     <!-- Mobile Menu Overlay -->
-    <div class="fixed inset-0 z-40 bg-black/95 backdrop-blur-xl transform translate-x-full transition-transform duration-300 md:hidden" id="mobileMenu">
-        <div class="flex flex-col items-center justify-center h-full gap-8">
-            <a href="#features" class="text-2xl font-medium text-gray-400 hover:text-white transition-colors">Platform</a>
-            <a href="#analytics" class="text-2xl font-medium text-gray-400 hover:text-white transition-colors">Analytics</a>
-            <a href="#pricing" class="text-2xl font-medium text-gray-400 hover:text-white transition-colors">Pricing</a>
-                <div class="flex flex-col gap-4 mt-12 mb-12 w-64">
-                    <button id="mobileLoginBtn" class="simple-btn-secondary w-full text-center" style="padding: 0.875rem;">Log in</button>
-                    <button id="mobileGetStartedBtn" class="simple-btn-primary w-full text-center" style="padding: 0.875rem;">Get Started</button>
-                </div>
-         </div>
+    <div class="landing-mobile-menu md:hidden" id="mobileMenu">
+        <div class="landing-mobile-menu-header">
+            <span class="landing-mobile-menu-title">Menu</span>
+            <button class="landing-mobile-close" id="mobileMenuClose" aria-label="Close navigation menu">
+                <i class="fas fa-xmark text-xl" aria-hidden="true"></i>
+            </button>
+        </div>
+        <nav class="landing-mobile-menu-links">
+            <a href="#features" class="landing-mobile-link">Platform</a>
+            <a href="#analytics" class="landing-mobile-link">Analytics</a>
+            <a href="#pricing" class="landing-mobile-link">Pricing</a>
+        </nav>
+        <div class="landing-mobile-menu-actions flex flex-col">
+            <button id="mobileLoginBtn" class="landing-mobile-button landing-mobile-button-secondary">Log in</button>
+            <button id="mobileGetStartedBtn" class="landing-mobile-button landing-mobile-button-primary" style="background:#ffffff;color:#000000;font-weight:600;">Get Started</button>
+        </div>
     </div>
 
 


### PR DESCRIPTION
The mobile hamburger menu drawer was unstyled because the HTML used Tailwind utility classes (text-2xl, font-medium, etc.) but Tailwind is not compiled in this project. Replaced them with the project-defined CSS classes from landing.css (.landing-mobile-menu, .landing-mobile-link, etc.) and added proper full-screen overlay positioning with backdrop blur. Updated the JS toggle to use open/close class instead of translate-x-full.

Fixes #44