### PR TITLE
fix: style mobile hamburger menu drawer on landing page

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -887,3 +887,13 @@ img {
 #mobileMenu {
     padding: 2rem;
 }
+
+#mobileMenu a {
+    text-decoration: none;
+    letter-spacing: 0.05em;
+    font-weight: 500;
+}
+
+#mobileMenu a:hover {
+    color: #ffffff;
+}

--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -843,3 +843,47 @@ img {
     max-width: 100%;
     height: auto;
 }
+
+/* Fix: Mobile hamburger drawer button styles */
+#mobileMenu .simple-btn-primary {
+    display: block;
+    width: 100%;
+    padding: 0.875rem 1.5rem;
+    background: #ffffff;
+    color: #000000;
+    font-weight: 600;
+    font-size: 0.875rem;
+    text-align: center;
+    border-radius: 0.75rem;
+    border: none;
+    cursor: pointer;
+    transition: background 0.2s;
+}
+
+#mobileMenu .simple-btn-primary:hover {
+    background: #e5e5e5;
+}
+
+#mobileMenu .simple-btn-secondary {
+    display: block;
+    width: 100%;
+    padding: 0.875rem 1.5rem;
+    background: transparent;
+    color: #ffffff;
+    font-weight: 600;
+    font-size: 0.875rem;
+    text-align: center;
+    border-radius: 0.75rem;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    cursor: pointer;
+    transition: border-color 0.2s, background 0.2s;
+}
+
+#mobileMenu .simple-btn-secondary:hover {
+    border-color: rgba(255, 255, 255, 0.6);
+    background: rgba(255, 255, 255, 0.05);
+}
+
+#mobileMenu {
+    padding: 2rem;
+}


### PR DESCRIPTION
Fixes #44 

## Changes
- Added missing CSS styles for `.simple-btn-primary` and `.simple-btn-secondary` inside the mobile drawer (`#mobileMenu`)
- Buttons now render with proper shape, padding, border-radius, and colors matching the desktop nav design
- Nav links were already functional; only the button styles were unstyled

## Testing
- Open site on mobile or resize browser to <768px
- Click hamburger icon → drawer opens
- Log In and Get Started buttons should now be properly styled

## Screenshot
<img width="1179" height="922" alt="image" src="https://github.com/user-attachments/assets/21fa5eb0-73ab-402f-bc8e-29246dd5cab0" />