### PR TITLE
perf: add preconnect hints for critical third-party origins

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>piik.me - Link Management & Analytics</title>
+    <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+    <link rel="preconnect" href="https://www.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+    <link rel="preconnect" href="https://unpkg.com" crossorigin>
+    <link rel="preconnect" href="https://d3js.org" crossorigin>
     <link rel="icon" type="image/png" href="assets/images/favicon.png">
     <link rel="stylesheet" href="css/styles.css">
     <link rel="stylesheet" href="css/bio-preview.css">


### PR DESCRIPTION
## Summary\n\nAdds preconnect link relations for the main third-party domains used by the application, reducing connection setup latency on initial load.\n\n## Changes\n\n- Added preconnect hints in public/index.html for:\n  - cdnjs.cloudflare.com (Font Awesome)\n  - www.gstatic.com (Firebase SDK)\n  - cdn.jsdelivr.net (Chart.js)\n  - unpkg.com (QRCode.js, Three.js, Globe.gl)\n  - d3js.org (D3 Scale)\n\nThese hints allow the browser to establish TCP/TLS handshakes early, improving perceived load time for users.\n\nCloses #85