### PR TITLE
feat(server): add link expiry with date and click limit

### DIFF
--- a/server.js
+++ b/server.js
@@ -152,7 +152,7 @@ function getBaseUrl(req) {
 
 // Create short link (requires authentication)
 app.post('/api/shorten', verifyToken, async (req, res) => {
-  const { url, utmParams, customShortCode, username } = req.body;
+  const { url, utmParams, customShortCode, username, expiresAt, maxClicks } = req.body;
   const userId = req.user.uid;
 
   if (!url) {
@@ -239,7 +239,10 @@ app.post('/api/shorten', verifyToken, async (req, res) => {
     createdAt: admin.firestore.FieldValue.serverTimestamp(),
     utmParams: parseUTMParams(finalUrl) || utmParams || {},
     isCustom: !!customShortCode,
-    isActive: true
+    isActive: true,
+    expiresAt: expiresAt ? admin.firestore.Timestamp.fromDate(new Date(expiresAt)) : null,
+    maxClicks: maxClicks ? parseInt(maxClicks, 10) : null,
+    clickCount: 0
   };
 
   const analyticsData = {
@@ -553,6 +556,24 @@ app.get('/api/user/links', verifyToken, async (req, res) => {
           .delete()
           .catch(() => { });
         continue;
+      }
+
+      // Auto-deactivate expired links (date-based or click-limit)
+      let expired = false;
+      if (linkData.expiresAt && linkData.expiresAt.toMillis() <= now.toMillis()) {
+        expired = true;
+      }
+      if (linkData.maxClicks && linkData.clickCount >= linkData.maxClicks) {
+        expired = true;
+      }
+
+      if (expired && linkData.isActive !== false) {
+        await db
+          .collection(COLLECTIONS.LINKS)
+          .doc(doc.id)
+          .update({ isActive: false })
+          .catch(() => { });
+        linkData.isActive = false;
       }
 
 
@@ -907,6 +928,18 @@ app.get('/:username/:slug', async (req, res) => {
     return res.status(404).send('Link not found');
   }
 
+  // Check expiry
+  if (link.expiresAt) {
+    const now = admin.firestore.Timestamp.now();
+    if (link.expiresAt.toMillis() <= now.toMillis()) {
+      return res.status(410).send('Link expired');
+    }
+  }
+
+  if (link.maxClicks && link.clickCount >= link.maxClicks) {
+    return res.status(410).send('Link click limit reached');
+  }
+
   // Extract request data before redirecting
   const userAgent = req.headers['user-agent'] || 'Unknown';
   const httpReferrer = req.headers['referer'] || req.headers['referrer'] || '';
@@ -1023,9 +1056,19 @@ app.get('/:username/:slug', async (req, res) => {
       location: locationData
     };
 
-    // Update analytics
+    // Update analytics and click count
     try {
       const firestoreId = toFirestoreId(shortCode);
+      const linkRef = db.collection(COLLECTIONS.LINKS).doc(firestoreId);
+      const linkDoc = await linkRef.get();
+
+      if (linkDoc.exists) {
+        // Increment click count
+        await linkRef.update({
+          clickCount: admin.firestore.FieldValue.increment(1)
+        });
+      }
+
       const analyticsRef = db.collection(COLLECTIONS.ANALYTICS).doc(firestoreId);
       const analyticsDoc = await analyticsRef.get();
 
@@ -1119,6 +1162,18 @@ app.get('/:shortCode', async (req, res) => {
 
   if (!link) {
     return res.status(404).send('Link not found');
+  }
+
+  // Check expiry
+  if (link.expiresAt) {
+    const now = admin.firestore.Timestamp.now();
+    if (link.expiresAt.toMillis() <= now.toMillis()) {
+      return res.status(410).send('Link expired');
+    }
+  }
+
+  if (link.maxClicks && link.clickCount >= link.maxClicks) {
+    return res.status(410).send('Link click limit reached');
   }
 
   // Extract request data before redirecting
@@ -1243,6 +1298,16 @@ app.get('/:shortCode', async (req, res) => {
     try {
       // Update Firestore
       const firestoreId = toFirestoreId(shortCode);
+      const linkRef = db.collection(COLLECTIONS.LINKS).doc(firestoreId);
+      const linkDoc = await linkRef.get();
+
+      if (linkDoc.exists) {
+        // Increment click count
+        await linkRef.update({
+          clickCount: admin.firestore.FieldValue.increment(1)
+        });
+      }
+
       const analyticsRef = db.collection(COLLECTIONS.ANALYTICS).doc(firestoreId);
       const doc = await analyticsRef.get();
       


### PR DESCRIPTION
feat(server): add link expiry with date and click limit

## Description

This PR adds user-controlled link expiry functionality with date-based and click-limit-based expiration.

## Changes

- **Link Creation API** (`/api/shorten`): Now accepts `expiresAt` (ISO date string) and `maxClicks` (integer) fields
- **Redirect Handlers** (`/:shortCode` and `/:username/:slug`): Check expiry before redirecting and return `410 Gone` for expired links
- **User Links API** (`/api/user/links`): Auto-deactivates expired links when fetching the list
- **Click Tracking**: Increments `clickCount` on each successful redirect to enforce click limits

## Features

- **Date-based expiry**: Links automatically deactivate after the specified datetime
- **Click-limit expiry**: Links deactivate after reaching the maximum click count
- **410 Gone response**: Returns proper HTTP status for expired/click-limited links instead of silent failures
- **Backward compatible**: Existing links without expiry fields continue to work indefinitely

## Testing

1. Create a link with expiry: `POST /api/shorten` with `{ "url": "...", "expiresAt": "2025-12-31T23:59:59Z" }`
2. Try to access the link after expiry - should get 410
3. Create a link with click limit: `POST /api/shorten` with `{ "url": "...", "maxClicks": 5 }`
4. Click the link 5 times - 6th click should return 410

## Related Issue

Closes #81
