### PR TITLE
chore: add SECURITY.md for responsible disclosure (Fixes #80)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Supported Versions
+
+We recommend updating to the latest stable release to receive security patches.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest  | ✅ Yes     |
+| < Latest| ❌ No      |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability within this project, please do not open a public issue. Instead, report it responsibly by contacting the maintainers directly or raising a private security advisory. We will investigate and address the issue as soon as possible.


### PR DESCRIPTION
This pull request implements the requested chore to add the missing `SECURITY.md` file.

Closes #80.