### PR TITLE
perf: implement preconnect for critical third-party origins (#85)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>piik.me - Link Management & Analytics</title>
     <link rel="icon" type="image/png" href="assets/images/favicon.png">
+    
+    <!-- Preconnect critical third-party origins -->
+    <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin />
+    <link rel="preconnect" href="https://www.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+
     <link rel="stylesheet" href="css/styles.css">
     <link rel="stylesheet" href="css/bio-preview.css">
     <link rel="stylesheet" href="css/version-banner.css">

--- a/public/landing.html
+++ b/public/landing.html
@@ -27,6 +27,8 @@
     <!-- Fonts: Inter -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+    <link rel="preconnect" href="https://www.gstatic.com" crossorigin>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" media="print" onload="this.media='all'">
     <noscript>
         <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap">


### PR DESCRIPTION
Fixes #85. Added <link rel=preconnect> for Google Fonts, gstatic, CDNJS, and jsDelivr to improve first-time render speed.