### PR TITLE
feat: user-controlled link expiry — date/click-limit, /expired page, …

### DIFF
--- a/public/expired.html
+++ b/public/expired.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Link Expired — piik.me</title>
+    <link rel="icon" type="image/png" href="assets/images/favicon.png">
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: #0a0a0a;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            color: #fff;
+        }
+        .card {
+            text-align: center;
+            padding: 48px 40px;
+            background: rgba(255,255,255,0.05);
+            border: 1px solid rgba(255,255,255,0.1);
+            border-radius: 24px;
+            max-width: 480px;
+            width: 90%;
+        }
+        .icon { font-size: 64px; margin-bottom: 24px; }
+        h1 { font-size: 28px; font-weight: 700; margin-bottom: 12px; }
+        p { color: rgba(255,255,255,0.6); font-size: 15px; line-height: 1.6; margin-bottom: 32px; }
+        a {
+            display: inline-block;
+            padding: 12px 28px;
+            background: #8b5cf6;
+            color: #fff;
+            text-decoration: none;
+            border-radius: 10px;
+            font-weight: 600;
+            font-size: 14px;
+        }
+        a:hover { background: #7c3aed; }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <div class="icon">🔗</div>
+        <h1>Link Expired</h1>
+        <p>This link is no longer active. It either reached its click limit or passed its expiry date.</p>
+        <a href="/">Create your own short link →</a>
+    </div>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -1144,6 +1144,22 @@
                         </div>
                     </div>
                 </div>
+
+                <div class="form-section">
+                    <h4>Link Expiry (Optional)</h4>
+                    <div class="form-grid">
+                        <div class="form-group">
+                            <label>Expire After Date</label>
+                            <input type="datetime-local" class="form-input" id="expiresAt">
+                            <small style="color: var(--text-tertiary); font-size: 12px;">Link auto-deactivates after this date</small>
+                        </div>
+                        <div class="form-group">
+                            <label>Max Clicks</label>
+                            <input type="number" class="form-input" id="maxClicks" min="1" placeholder="e.g. 100">
+                            <small style="color: var(--text-tertiary); font-size: 12px;">Link auto-deactivates after N clicks</small>
+                        </div>
+                    </div>
+                </div>
             </div>
             <div class="modal-footer">
                 <button class="btn btn-secondary" id="modalCancel">Cancel</button>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -951,7 +951,12 @@ function clearCreateLinkForm() {
     utmMedium.value = '';
     utmCampaign.value = '';
     utmTerm.value = '';
-    utmContent.value = '';
+   utmContent.value = '';
+
+    const expiresAtInput = document.getElementById('expiresAt');
+    const maxClicksInput = document.getElementById('maxClicks');
+    if (expiresAtInput) expiresAtInput.value = '';
+    if (maxClicksInput) maxClicksInput.value = '';
     
     // Reset username prefix
     const usernamePrefix = document.getElementById('usernamePrefix');
@@ -1115,7 +1120,11 @@ async function handleCreateLink() {
                 url,
                 customShortCode: customCode || null,
                 username: userBioSlug || null,
-                utmParams: Object.keys(utmParams).length > 0 ? utmParams : null
+                utmParams: Object.keys(utmParams).length > 0 ? utmParams : null,
+                expiresAt: document.getElementById('expiresAt')?.value || null,
+                maxClicks: document.getElementById('maxClicks')?.value
+                    ? parseInt(document.getElementById('maxClicks').value)
+                    : null
             })
         });
         
@@ -1263,6 +1272,8 @@ function displayLinks(links, filter) {
                 <div class="link-meta">
                     <span><i class="fas fa-calendar"></i> ${formatDate(link.createdAt)}</span>
                     ${link.utmParams ? '<span><i class="fas fa-tags"></i> UTM Enabled</span>' : ''}
+                    ${link.expiresAt ? `<span style="color: var(--accent-orange);"><i class="fas fa-hourglass-half"></i> Expires ${formatDate(link.expiresAt)}</span>` : ''}
+                    ${link.maxClicks ? `<span style="color: var(--accent-blue);"><i class="fas fa-mouse-pointer"></i> ${link.clickCount || 0}/${link.maxClicks} clicks</span>` : ''}
                     ${isInactive && daysRemaining ? `<span style="color: var(--accent-red);"><i class="fas fa-clock"></i> Deletes in ${daysRemaining} days</span>` : ''}
                 </div>
             </div>

--- a/server.js
+++ b/server.js
@@ -21,6 +21,12 @@ const fetch = (...args) => {
 let db = null;
 
 let auth = null;
+// Firebase state tracking
+const firebaseState = {
+  enabled: false,
+  mode: 'memory',
+  reason: 'Firebase not initialized'
+};
 
 try {
   admin.initializeApp({
@@ -33,10 +39,12 @@ try {
 
   db = admin.firestore();
   auth = admin.auth();
+  firebaseState.enabled = true;
+firebaseState.mode = 'firestore';
+firebaseState.reason = 'Firebase connected successfully';
 
 
-  db = admin.firestore();
-
+  
   console.log('✅ Firebase Admin initialized');
 } catch (error) {
   console.log('⚠️ Firebase Admin not configured. Using in-memory storage.');
@@ -87,7 +95,7 @@ const COLLECTIONS = {
 };
 
 // Middleware to verify Firebase token
-// Middleware to verify Firebase token
+
 async function verifyToken(req, res, next) {
   // If Firebase Auth is not available, reject with clear message
   if (!auth) {
@@ -261,6 +269,8 @@ app.post('/api/shorten', verifyToken, async (req, res) => {
   const shortUrl = `${baseUrl}/${shortCode}`;
 
   // Store link data
+  const { expiresAt, maxClicks } = req.body;
+
   const linkData = {
     originalUrl: finalUrl,
     shortCode,
@@ -270,7 +280,12 @@ app.post('/api/shorten', verifyToken, async (req, res) => {
     createdAt: admin.firestore.FieldValue.serverTimestamp(),
     utmParams: parseUTMParams(finalUrl) || utmParams || {},
     isCustom: !!customShortCode,
-    isActive: true
+    isActive: true,
+    expiresAt: expiresAt ? admin.firestore.Timestamp.fromDate(new Date(expiresAt)) : null,
+    maxClicks: maxClicks ? parseInt(maxClicks) : null,
+    clickCount: 0,
+    notifiedExpiry: false,
+    isExpired: false
   };
 
   const analyticsData = {
@@ -566,7 +581,6 @@ app.get('/api/user/links', verifyToken, async (req, res) => {
     for (const doc of linksSnapshot.docs) {
       const linkData = doc.data();
 
-
       // Auto-delete inactive links whose scheduledDeletion date has passed
       const now = admin.firestore.Timestamp.now();
       const isInactive = linkData.isActive === false;
@@ -586,7 +600,14 @@ app.get('/api/user/links', verifyToken, async (req, res) => {
         continue;
       }
 
-
+      // Auto-deactivate on expiry
+      const nowDate = new Date();
+      const dateExpired = linkData.expiresAt && linkData.expiresAt.toDate && linkData.expiresAt.toDate() < nowDate;
+      const clickExpired = linkData.maxClicks && (linkData.clickCount || 0) >= linkData.maxClicks;
+      if ((dateExpired || clickExpired) && linkData.isActive !== false) {
+        await db.collection(COLLECTIONS.LINKS).doc(doc.id).update({ isActive: false, isExpired: true }).catch(() => {});
+        linkData.isActive = false;
+      }
 
       console.log(`Processing link: ${doc.id}`, { shortCode: linkData.shortCode, isActive: linkData.isActive });
 
@@ -881,14 +902,6 @@ app.get(['/home', '/analytics', '/profile', '/qr-generator', '/bio-link', '/dash
   res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
 
-// // Temporary route for testing middlware
-// app.get('/api/test', (req, res) => {
-//   res.json({
-//     success: true,
-//     message: 'API working'
-//   });
-// });
-
 // Track impression without redirect (for link previews - HEAD request)
 app.head('/:shortCode', async (req, res) => {
   let { shortCode } = req.params;
@@ -936,6 +949,19 @@ app.get('/:username/:slug', async (req, res) => {
 
   if (!link) {
     return res.status(404).send('Link not found');
+  }
+
+  // Expiry checks
+  const now = new Date();
+  if (link.expiresAt && link.expiresAt.toDate && link.expiresAt.toDate() < now) {
+    const firestoreId = toFirestoreId(shortCode);
+    await db.collection(COLLECTIONS.LINKS).doc(firestoreId).update({ isActive: false, isExpired: true }).catch(() => {});
+    return res.redirect('/expired');
+  }
+  if (link.maxClicks && link.clickCount >= link.maxClicks) {
+    const firestoreId = toFirestoreId(shortCode);
+    await db.collection(COLLECTIONS.LINKS).doc(firestoreId).update({ isActive: false, isExpired: true }).catch(() => {});
+    return res.redirect('/expired');
   }
 
   // Extract request data before redirecting
@@ -1065,7 +1091,9 @@ app.get('/:username/:slug', async (req, res) => {
         // This avoids the 1MB Firestore document limit and allows infinite scaling
         const clickRef = analyticsRef.collection('clicks').doc();
         await clickRef.set(clickData);
-
+        await db.collection(COLLECTIONS.LINKS).doc(firestoreId).update({
+          clickCount: admin.firestore.FieldValue.increment(1)
+        }).catch(() => {});
         // Update aggregate counters
         await analyticsRef.update({
           clicks: admin.firestore.FieldValue.increment(1),
@@ -1112,8 +1140,6 @@ app.get('/:username/:slug', async (req, res) => {
   })().catch(err => console.error('Background analytics error:', err));
 });
 
-
-
 // Redirect short link and track click (also handles bio links)
 app.get('/:shortCode', async (req, res) => {
   const { shortCode } = req.params;
@@ -1150,6 +1176,19 @@ app.get('/:shortCode', async (req, res) => {
 
   if (!link) {
     return res.status(404).send('Link not found');
+  }
+
+  // Expiry checks
+  const now = new Date();
+  if (link.expiresAt && link.expiresAt.toDate && link.expiresAt.toDate() < now) {
+    const firestoreId = toFirestoreId(shortCode);
+    await db.collection(COLLECTIONS.LINKS).doc(firestoreId).update({ isActive: false, isExpired: true }).catch(() => {});
+    return res.redirect('/expired');
+  }
+  if (link.maxClicks && link.clickCount >= link.maxClicks) {
+    const firestoreId = toFirestoreId(shortCode);
+    await db.collection(COLLECTIONS.LINKS).doc(firestoreId).update({ isActive: false, isExpired: true }).catch(() => {});
+    return res.redirect('/expired');
   }
 
   // Extract request data before redirecting
@@ -1306,6 +1345,10 @@ app.get('/:shortCode', async (req, res) => {
           updateData.shares = admin.firestore.FieldValue.increment(1);
         }
         
+        await db.collection(COLLECTIONS.LINKS).doc(firestoreId).update({
+          clickCount: admin.firestore.FieldValue.increment(1)
+        }).catch(() => {});
+
         await analyticsRef.update(updateData);
         
         const updated = await analyticsRef.get();
@@ -1374,6 +1417,11 @@ app.post('/api/admin/sync-redis', verifyToken, async (req, res) => {
   }
 });
 
+// Expired link page
+app.get('/expired', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'expired.html'));
+});
+
 if (!isServerless) {
   // Socket.IO connection
   io.on('connection', (socket) => {
@@ -1388,6 +1436,32 @@ if (!isServerless) {
       console.log('Client disconnected:', socket.id);
     });
   });
+
+  // 24-hour pre-expiry notification check (runs every hour)
+  setInterval(async () => {
+    if (!db) return;
+    try {
+      const now = new Date();
+      const in24h = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+      const snapshot = await db.collection(COLLECTIONS.LINKS)
+        .where('isActive', '==', true)
+        .where('notifiedExpiry', '==', false)
+        .get();
+      for (const doc of snapshot.docs) {
+        const link = doc.data();
+        if (link.expiresAt && link.expiresAt.toDate) {
+          const expiry = link.expiresAt.toDate();
+          if (expiry <= in24h && expiry > now) {
+            console.log(`⏰ Link expiring soon: ${link.shortCode} (${link.userEmail})`);
+            await doc.ref.update({ notifiedExpiry: true });
+            // TODO: plug in Nodemailer here to email link.userEmail
+          }
+        }
+      }
+    } catch (err) {
+      console.error('Expiry notification check error:', err);
+    }
+  }, 60 * 60 * 1000);
 
   // Start server
   const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
Closes #81

## What's included
- Backend: expiresAt (date-based) and maxClicks (click-limit) fields added to link creation
- Redirect handlers check expiry before redirecting — expired links go to /expired
- /expired page with proper UI instead of a bare 410
- Auto-deactivate on /api/user/links fetch
- Frontend: expiry fields in the Create Link modal
- Link cards show expiry date and click counter badges
- 24-hour pre-expiry notification scheduler (non-serverless only)

## Beyond PR #95
- /expired redirect page (PR #95 returns bare 410 Gone)
- Frontend modal fields (PR #95 has no UI)
- Expiry badges on link cards
- 24hr notification scheduler