### PR TITLE
Add error toast handling for /api/shorten API failures

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1120,6 +1120,16 @@ async function handleCreateLink() {
             })
         });
         
+        if (!response.ok) {
+            let errorMsg = 'Failed to create link';
+            try {
+                const errData = await response.json();
+                errorMsg = errData.error || errData.message || errorMsg;
+            } catch (_) {}
+            showToast(errorMsg, 'error');
+            return;
+        }
+        
         const data = await response.json();
         console.log('Link creation response:', data);
         
@@ -1135,7 +1145,7 @@ async function handleCreateLink() {
         }
     } catch (error) {
         console.error('Error:', error);
-        showToast('Failed to create link. Please try again.', 'error');
+        showToast(error.message || 'Failed to create link. Please try again.', 'error');
     } finally {
         createLinkSubmit.disabled = false;
         createLinkSubmit.innerHTML = '<i class="fas fa-plus"></i> Create Link';


### PR DESCRIPTION
## Summary

Fixes silent URL shortening failures by adding proper error handling for non-2xx API responses:

- Checks response.ok before parsing JSON
- Extracts the actual error message from the API response body
- Shows the specific error in a toast instead of the generic 'try again' message
- Includes the HTTP error message in the catch fallback toast