### PR TITLE
fix(analytics): require authentication on GET /api/analytics/:shortCode

### DIFF
--- a/server.js
+++ b/server.js
@@ -424,8 +424,8 @@ app.post('/api/shorten', verifyToken, async (req, res) => {
   }
 });
 
-// Get analytics for a short link
-app.get('/api/analytics/:shortCode', async (req, res) => {
+// Get analytics for a short link (requires authentication)
+app.get('/api/analytics/:shortCode', verifyToken, async (req, res) => {
   const { shortCode } = req.params;
   
   try {


### PR DESCRIPTION
## Description

Closes #124

`GET /api/analytics/:shortCode` returned full click history, including IP addresses, geolocation data, and user agents, to any unauthenticated caller. Every other data-sensitive route in `server.js` used the `verifyToken` middleware, but this endpoint was missing it, making all link analytics publicly accessible without any credentials.

**Root cause:** the route was registered without the `verifyToken` middleware that all other protected routes use.

**Fix:** add `verifyToken` as the second argument to the `app.get('/api/analytics/:shortCode', ...)` call. Unauthenticated requests now receive `401 Unauthorized` before any data is read from Firestore.

## Related Issue

Closes #124

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `server.js`: added `verifyToken` middleware to `GET /api/analytics/:shortCode`. Updated the route comment to reflect that authentication is now required.

## Screenshots / Video (if applicable)

Not applicable. This is a server-side access control fix with no visual change.

## Testing Done

1. Send `GET /api/analytics/some-code` with no `Authorization` header. Confirm `401 Unauthorized` is returned.
2. Send the same request with a valid Firebase ID token in the `Authorization: Bearer <token>` header. Confirm analytics are returned as before.
3. Verify all other authenticated routes continue to work correctly.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] There are no merge conflicts with the base branch
- [x] I have not used any AI-generated content in this PR

## GSSoC Label Request

Could you please add the appropriate GSSoC 2026 label to this PR? It helps with tracking and scoring under GSSoC '26. Thank you!

program: gssoc