### PR TITLE
fix(cors): restrict Express CORS and Socket.IO origin to ALLOWED_ORIGIN env var

### DIFF
--- a/server.js
+++ b/server.js
@@ -55,11 +55,15 @@ firebaseState.reason = 'Firebase connected successfully';
 const app = express();
 const isServerless = Boolean(process.env.VERCEL || process.env.AWS_LAMBDA_FUNCTION_NAME);
 const server = isServerless ? null : http.createServer(app);
+// Restrict Socket.IO CORS to the configured application origin.
+// Falls back to the same ALLOWED_ORIGIN used for the Express CORS middleware
+// so both share a single configuration point in the environment.
+const allowedOrigin = process.env.ALLOWED_ORIGIN || false;
 const io = isServerless
   ? { emit: () => {} }
   : socketIo(server, {
       cors: {
-        origin: "*",
+        origin: allowedOrigin,
         methods: ["GET", "POST"]
       }
     });
@@ -79,7 +83,15 @@ function fromFirestoreId(firestoreId) {
 // Middleware
 app.use(securityHeaders);
 app.use(apiLimiter);
-app.use(cors());
+// Restrict CORS to the configured application origin.
+// Without an origin restriction, any third-party website can make credentialed
+// cross-origin requests to the API. Set ALLOWED_ORIGIN in the environment to
+// the production front-end URL (e.g. https://piik.me). When unset, cross-origin
+// requests are blocked entirely (origin: false) rather than allowed for all.
+app.use(cors({
+  origin: process.env.ALLOWED_ORIGIN || false,
+  credentials: true,
+}));
 app.use(express.json());
 app.use(express.static('public', { index: false }));
 app.use((req, res, next) => {


### PR DESCRIPTION
## Description

Closes #126

`server.js` configured both the Express CORS middleware and Socket.IO with wildcard origins:

```js
app.use(cors());                           // defaults to origin: '*'
socketIo(server, { cors: { origin: '*' } }) // explicit wildcard
```

With `origin: '*'`, any external website could make cross-origin requests to all API endpoints. Combined with Firebase token authentication (bearer tokens), this meant a malicious site could trick a logged-in user's browser into sending credentialed requests to the API.

**Fix:** replace both wildcards with `process.env.ALLOWED_ORIGIN`, using a single environment variable as the shared configuration point for both the Express and Socket.IO CORS settings. When `ALLOWED_ORIGIN` is not set the origin defaults to `false`, which blocks all cross-origin requests rather than permitting them for all.

## Related Issue

Closes #126

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `server.js`:
  - `app.use(cors())` replaced with `app.use(cors({ origin: process.env.ALLOWED_ORIGIN || false, credentials: true }))`.
  - Socket.IO `cors.origin` changed from `'*'` to `process.env.ALLOWED_ORIGIN || false`.
  - Both now use the same environment variable so operators have a single place to configure the allowed origin.

## Screenshots / Video (if applicable)

Not applicable. This is a server-side security configuration fix.

## Testing Done

1. Start the server with `ALLOWED_ORIGIN=https://piik.me`. Make a cross-origin request from `https://piik.me`. Confirm it succeeds.
2. Make a cross-origin request from `https://attacker.com`. Confirm `CORS error` in the browser.
3. Start the server without `ALLOWED_ORIGIN`. Make any cross-origin request. Confirm all cross-origin requests are blocked.
4. Verify same-origin requests (no `Origin` header) still work normally.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] There are no merge conflicts with the base branch
- [x] I have not used any AI-generated content in this PR

## GSSoC Label Request

Could you please add the appropriate GSSoC 2026 label to this PR? It helps with tracking and scoring under GSSoC '26. Thank you!

program: gssoc