### PR TITLE
fix(bug-report): require authentication and add strict rate limit on POST /api/bug-report

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ const admin = require('firebase-admin');
 const fetch = require('node-fetch');
 const redisUtils = require('./src/utils/redis.utils');
 const redirectCache = require('./src/utils/redirect-cache.utils');
-const { securityHeaders, apiLimiter } = require('./src/middleware/security.middleware');
+const { securityHeaders, apiLimiter, bugReportLimiter } = require('./src/middleware/security.middleware');
 require('dotenv').config();
 const fetch = (...args) => {
   if (typeof globalThis.fetch === 'function') {
@@ -962,8 +962,8 @@ app.post('/api/track/share/:shortCode', async (req, res) => {
   res.json({ success: true, message: 'Shares tracked via UTM parameters' });
 });
 
-// Create GitHub Issue for Bug Report
-app.post('/api/bug-report', async (req, res) => {
+// Create GitHub Issue for Bug Report (requires authentication + strict rate limit)
+app.post('/api/bug-report', verifyToken, bugReportLimiter, async (req, res) => {
   try {
     const { title, description, steps, email, userId, userEmail } = req.body;
     

--- a/src/middleware/security.middleware.js
+++ b/src/middleware/security.middleware.js
@@ -65,4 +65,21 @@ const apiLimiter = rateLimit({
     }
 });
 
-module.exports = { securityHeaders, apiLimiter };
+/**
+ * Strict rate limiter for the bug-report endpoint.
+ * Each IP is capped at 5 reports per hour. The endpoint uses the server's
+ * GITHUB_TOKEN to create GitHub issues, so unrestricted access lets any
+ * caller exhaust the token's API quota and flood the repository with spam.
+ */
+const bugReportLimiter = rateLimit({
+    windowMs: 60 * 60 * 1000, // 1 hour
+    max: 5,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: {
+        success: false,
+        error: 'Too many bug reports submitted. Please wait before trying again.'
+    }
+});
+
+module.exports = { securityHeaders, apiLimiter, bugReportLimiter };


### PR DESCRIPTION
## Description

Closes #127

`POST /api/bug-report` had no authentication and no rate limiting. It used the server's `GITHUB_TOKEN` to create real GitHub issues in the repository, so any anonymous caller could send unlimited requests and either exhaust the token's API quota (60 unauthenticated requests per hour or 5000 per hour for the token) or flood the repository with spam issues.

**Root cause:** the route was registered without `verifyToken` middleware and without any per-endpoint throttle beyond the broad global `apiLimiter` (100 requests per 15 minutes, shared across all routes).

**Fix:**
1. Add `verifyToken` as the first middleware so only Firebase-authenticated users can reach the handler.
2. Export a new `bugReportLimiter` from `security.middleware.js` (5 requests per IP per hour) and apply it as the second middleware after `verifyToken`. This keeps the rate window tight without affecting any other routes.

## Related Issue

Closes #127

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `src/middleware/security.middleware.js`: added and exported `bugReportLimiter` (5 req / IP / 1 hour window) using the existing `express-rate-limit` dependency.
- `server.js`:
  - Imported `bugReportLimiter` from the security middleware.
  - Added `verifyToken` and `bugReportLimiter` to `POST /api/bug-report`.

## Screenshots / Video (if applicable)

Not applicable. This is a server-side access control and rate limiting fix.

## Testing Done

1. Send `POST /api/bug-report` with no `Authorization` header. Confirm `401 Unauthorized`.
2. Send with a valid Firebase ID token. Confirm the bug report is created and a GitHub issue is opened as before.
3. Send 6 authenticated requests in under an hour from the same IP. Confirm the 6th returns `429 Too many bug reports submitted`.
4. Verify all other API routes are unaffected by the new rate limiter.

## Checklist

- [x] I have read the CONTRIBUTING.md and followed its guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] There are no merge conflicts with the base branch
- [x] I have not used any AI-generated content in this PR

## GSSoC Label Request

Could you please add the appropriate GSSoC 2026 label to this PR? It helps with tracking and scoring under GSSoC '26. Thank you!

program: gssoc