### PR TITLE
feat: add SEO and social sharing meta tags to index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,23 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>piik.me - Link Management & Analytics</title>
     <link rel="icon" type="image/png" href="assets/images/favicon.png">
-    
+    <meta name="description" content="piik.me - Intelligent link management platform with real-time analytics, custom domains, QR code generation, and bio link pages.">
+    <meta name="keywords" content="link shortener, link management, URL shortener, analytics, QR code, bio link, piik.me">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://piik.me/">
+    <meta property="og:title" content="piik.me - Link Management & Analytics">
+    <meta property="og:description" content="Intelligent link management platform with real-time analytics, custom domains, QR code generation, and bio link pages.">
+    <meta property="og:image" content="assets/images/favicon.png">
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="https://piik.me/">
+    <meta property="twitter:title" content="piik.me - Link Management & Analytics">
+    <meta property="twitter:description" content="Intelligent link management platform with real-time analytics, custom domains, QR code generation, and bio link pages.">
+    <meta property="twitter:image" content="assets/images/favicon.png">
+
     <!-- Preconnect critical third-party origins -->
     <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin />
     <link rel="preconnect" href="https://www.gstatic.com" crossorigin />


### PR DESCRIPTION
## Summary

Added comprehensive SEO and social sharing meta tags to `public/index.html` — including standard SEO tags (description, keywords), Open Graph tags (Facebook, Slack, LinkedIn), and Twitter Card tags — to improve search engine visibility and social media link previews.

## Related Issue

Fixes #113

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code style / formatting
- [ ] Refactor
- [ ] Chore / maintenance

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide
- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
- [x] I have linked related issues
- [ ] I have included screenshots for UI changes (if applicable)

## Notes

Follows the same meta tag conventions as `landing.html` — consistent `property` attribute usage, `summary_large_image` card type, and relative `og:image` path pointing to `assets/images/favicon.png`.