### PR TITLE
fix: update bio.html favicon to point to existing PNG asset

### DIFF
--- a/public/bio.html
+++ b/public/bio.html
@@ -18,8 +18,7 @@
     <meta name="twitter:image" content="">
     
     <!-- Favicon -->
-    <link rel="icon" type="image/x-icon" href="/assets/icons/favicon.ico">
-    <link rel="icon" type="image/svg+xml" href="/assets/icons/favicon.svg">
+    <link rel="icon" type="image/png" href="assets/images/favicon.png">
     
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -237,6 +237,13 @@ function navigateToPage(page, updateHistory = true) {
         page = 'home';
     }
     
+    // Stop analytics polling when leaving the analytics page
+    if (window.analyticsPollInterval) {
+        clearInterval(window.analyticsPollInterval);
+        window.analyticsPollInterval = null;
+        window.analyticsPollFilter = null;
+    }
+    
     currentPage = page;
     
     // Update browser URL without reloading
@@ -2433,6 +2440,7 @@ async function loadAnalyticsData(linkFilter) {
             const linkData = entry.linkData || {};
             const shortCode = entry.shortCode;
             const analytics = entry.analytics;
+            if (!analytics) continue; // Skip entries with no analytics data
                 
                 // Read split test if filtering by a single link
                 if (linkFilter !== 'all' && linkData.splitTest) {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2376,6 +2376,18 @@ function startAnalyticsPolling(linkFilter) {
     window.analyticsPollFilter = linkFilter;
 }
 
+// Reset analytics UI to empty state (used in error/no-data paths)
+function updateAnalyticsUI(impressions, clicks, ctr, visitors, countries, devices, browsers, referrers) {
+    const setText = (id, val) => {
+        const el = document.getElementById(id);
+        if (el) el.textContent = val;
+    };
+    setText('analyticsImpressions', (impressions || 0).toLocaleString());
+    setText('analyticsClicks', (clicks || 0).toLocaleString());
+    setText('analyticsCTR', (ctr || 0).toFixed(1) + '%');
+    setText('analyticsVisitors', (visitors || 0).toLocaleString());
+}
+
 async function loadAnalyticsData(linkFilter) {
     try {
         // Check if user is authenticated

--- a/public/js/bio-link.js
+++ b/public/js/bio-link.js
@@ -154,9 +154,10 @@ async function loadBioLinks() {
         console.log('Loaded', bioLinks.length, 'bio links');
 
         // Sort by creation date (most recent first)
+        // Handles both raw Firestore Timestamps (.toDate()) and already-parsed Date objects
         bioLinks.sort((a, b) => {
-            const dateA = a.createdAt?.toDate?.() || new Date(0);
-            const dateB = b.createdAt?.toDate?.() || new Date(0);
+            const dateA = a.createdAt instanceof Date ? a.createdAt.getTime() : (a.createdAt?.toDate?.()?.getTime() || 0);
+            const dateB = b.createdAt instanceof Date ? b.createdAt.getTime() : (b.createdAt?.toDate?.()?.getTime() || 0);
             return dateB - dateA;
         });
 

--- a/public/js/qr-generator.js
+++ b/public/js/qr-generator.js
@@ -879,12 +879,6 @@ const QRGenerator = {
                 return;
             }
             
-            links.sort((a, b) => {
-                const dateA = a.createdAt ? new Date(a.createdAt) : new Date(0);
-                const dateB = b.createdAt ? new Date(b.createdAt) : new Date(0);
-                return dateB - dateA;
-            });
-            
             const recentLinks = links.slice(0, 6);
 
             this.quickLinksGrid.innerHTML = '';

--- a/server.js
+++ b/server.js
@@ -428,6 +428,10 @@ app.post('/api/shorten', verifyToken, async (req, res) => {
 app.get('/api/user/analytics', verifyToken, async (req, res) => {
   const userId = req.user.uid;
 
+  if (!db) {
+    return res.status(503).json({ error: 'Firestore not available' });
+  }
+
   try {
     const linksSnapshot = await db.collection(COLLECTIONS.LINKS)
       .where('userId', '==', userId)
@@ -1052,7 +1056,7 @@ app.put('/api/links/:shortCode/reactivate', verifyToken, async (req, res) => {
     });
 
     // Restore in Redis
-    await redisUtils.setLinkInRedis(shortCode, { ...linkData, isActive: true });
+    await redisUtils.storeLinkInRedis(shortCode, { ...linkData, isActive: true });
 
     res.json({ success: true, message: 'Link reactivated successfully' });
   } catch (error) {
@@ -1075,15 +1079,44 @@ app.delete('/api/links/inactive', verifyToken, async (req, res) => {
       return res.json({ success: true, message: 'No inactive links to delete', count: 0 });
     }
 
-    const batch = db.batch();
+    const BATCH_LIMIT = 400;
     let count = 0;
+    let currentBatch = db.batch();
+    let batchOps = 0;
 
-    inactiveLinksQuery.docs.forEach(doc => {
-      batch.delete(doc.ref);
+    for (const doc of inactiveLinksQuery.docs) {
+      const data = doc.data();
+      const shortCode = data.shortCode;
+      if (!shortCode) continue;
+
+      // Delete link document
+      currentBatch.delete(doc.ref);
+      batchOps++;
+
+      // Delete associated analytics document
+      const firestoreId = toFirestoreId(shortCode);
+      const analyticsRef = db.collection(COLLECTIONS.ANALYTICS).doc(firestoreId);
+      currentBatch.delete(analyticsRef);
+      batchOps++;
+
+      // Clear cache
+      await redisUtils.deleteLinkFromRedis(shortCode).catch(() => {});
+      await redirectCache.delete(shortCode).catch(() => {});
+
       count++;
-    });
 
-    await batch.commit();
+      // Firestore batch limit is 500 — commit + refresh at 400 to stay safe
+      if (batchOps >= BATCH_LIMIT) {
+        await currentBatch.commit();
+        currentBatch = db.batch();
+        batchOps = 0;
+      }
+    }
+
+    // Commit remaining batch
+    if (batchOps > 0) {
+      await currentBatch.commit();
+    }
 
     res.json({ success: true, message: `Successfully deleted ${count} inactive link${count > 1 ? 's' : ''}`, count });
   } catch (error) {

--- a/server.js
+++ b/server.js
@@ -5,7 +5,6 @@ const cors = require('cors');
 const path = require('path');
 const { nanoid } = require('nanoid');
 const admin = require('firebase-admin');
-const fetch = require('node-fetch');
 const redisUtils = require('./src/utils/redis.utils');
 const redirectCache = require('./src/utils/redirect-cache.utils');
 const { securityHeaders, apiLimiter } = require('./src/middleware/security.middleware');

--- a/server.js
+++ b/server.js
@@ -15,6 +15,7 @@ const fetch = typeof globalThis.fetch === 'function'
 const redisUtils = require('./src/utils/redis.utils');
 const redirectCache = require('./src/utils/redirect-cache.utils');
 const { securityHeaders, apiLimiter, bugReportLimiter } = require('./src/middleware/security.middleware');
+const splitTestService = require('./src/services/splitTest.service');
 require('dotenv').config();
 
 // Initialize Firebase Admin


### PR DESCRIPTION
## Summary

This PR migrates bio-link management, link lifecycle operations, and analytics loading from direct Firebase/Firestore access to authenticated REST API endpoints, with corresponding server-side implementation. It also fixes the bio page favicon 404, resolves a critical server startup crash (`SyntaxError: Identifier 'fetch' has already been declared`), fixes 7 CodeRabbit review findings, and adds 2 missing definitions (`updateAnalyticsUI`, `splitTestService`) that caused runtime errors.

### API Migration (Issue #111)

**Server — new endpoints** (`server.js`):
- `GET /api/user/analytics` — aggregated analytics for all user links
- `GET /api/bio-links` — list user bio links
- `POST /api/bio-links` — create bio link (slug uniqueness, one-per-user enforcement)
- `PUT /api/bio-links/:id` — update bio link (ownership + slug-change validation)
- `DELETE /api/bio-links/:id` — delete bio link (ownership check)
- `GET /api/bio-links/check-slug/:slug` — slug availability check
- `PUT /api/links/:shortCode/deactivate` — soft-delete with 15-day scheduled deletion
- `PUT /api/links/:shortCode/reactivate` — restore deactivated link
- `DELETE /api/links/inactive` — permanently delete all inactive links (now cleans analytics docs + cache + chunked at 400 ops)

All endpoints use `verifyToken` middleware with server-side ownership verification.

**Client — Firestore replaced with API calls**:
- `public/js/app.js` — `deleteLink()`, `reactivateLink()`, `permanentlyDeleteInactiveLinks()`, `loadAnalyticsData()`, `loadDetailedGeographicData()`, `openSplitTestModal()` migrated from Firestore to authenticated `fetch()`. Replaced `onSnapshot` real-time listeners with 5s polling (cleaned up on navigation).
- `public/js/bio-link.js` — `loadBioLinks()`, `saveBioLink()`, `deleteBioLink()`, slug checks rewritten with `apiCall()` helper + `parseTimestamps()`. Fixed sorting comparator to handle both `Date` objects and raw Firestore Timestamps.
- `public/js/qr-generator.js` — quick links grid now fetches from `GET /api/user/links`. Removed redundant broken client-side sort.

### Bug Fixes

| Severity | Issue | Fix |
|----------|-------|-----|
| 🔴 Critical | Server crash at startup — duplicate `const fetch` declarations (`require('node-fetch')` + wrapper) throwing `SyntaxError` on Node.js v18+ | Removed duplicate; uses main's cleaner ternary: `typeof globalThis.fetch === 'function' ? globalThis.fetch : (...args) => import('node-fetch')...` |
| 🔴 Critical | `redisUtils.setLinkInRedis()` doesn't exist — link reactivation throws `TypeError` | Corrected to `redisUtils.storeLinkInRedis()` |
| 🔴 Critical | `updateAnalyticsUI` called in 3 error paths but never defined — `ReferenceError` on API failure | Added function that resets analytics stat elements to zero |
| 🔴 Critical | `splitTestService` used for variant validation but never imported — `ReferenceError` on split-test ops | Added `require('./src/services/splitTest.service')` |
| 🔴 Critical | `loadAnalyticsData()` accesses `analytics.variantClicks` without null check — `TypeError` when `result.analytics` is null | Added `if (!analytics) continue` guard |
| 🟡 High | Bio-link sort broken after `parseTimestamps()` — `Date` has no `.toDate()` method, all items fall back to `new Date(0)` | Comparator handles both `Date` instances and raw Timestamps |
| 🟡 High | Bulk delete leaves analytics docs + Redis/redirect cache stale | Now deletes analytics docs, clears cache, chunks at 400 ops per batch |
| 🟡 High | Analytics polling continues off-page — unnecessary API calls every 5s | Clear interval + filter in `navigateToPage()` |
| 🟡 High | No Firestore availability guard — crashes if `db` is null | Return 503 on `GET /api/user/analytics` if `db` is null |
| 🟢 Low | Bio page favicon 404 — broken links to non-existent `favicon.ico` and `favicon.svg` | Replaced with reference to existing `assets/images/favicon.png` |

## Related Issue

Fixes #110, #123  
Implements #111

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code style / formatting
- [x] Refactor
- [ ] Chore / maintenance

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide
- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
- [x] I have linked related issues
- [ ] I have included screenshots for UI changes (if applicable)

## Notes

- All new endpoints use `verifyToken` middleware — frontend must pass `Authorization: Bearer {token}`
- Analytics real-time updates use polling (5s interval) instead of Firestore `onSnapshot` — no Socket.IO dependency needed
- `DELETE /api/links/inactive` is placed before `DELETE /api/links/:shortCode` to avoid Express route capture
- Bulk delete batches at 400 ops to stay within Firestore's 500-op batch limit
- Backward compatible — UI behavior is unchanged
- The `main` branch merge resolved a conflict in the `fetch` declaration, adopting the cleaner ternary assignment from upstream

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stop analytics polling when leaving the Analytics page; skip missing analytics entries to avoid incorrect stats
  * API now returns a clear error when analytics backend is unavailable

* **Improvements**
  * Better handling of date formats when sorting bio links
  * Quick-link generation uses server order for faster rendering
  * Safer, batched removal of inactive links with cache clearing to prevent stale redirects

<!-- end of auto-generated comment: release notes by coderabbit.ai -->