### PR TITLE
feat: add date range filter to clicks over time analytics chart

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -93,12 +93,27 @@ html[data-theme="dark"] {
 }
 .date-range-btn {
     background: transparent;
-    border: 1px solid var(--border-color);
+    border: 1px solid var(--border-primary);
     color: var(--text-secondary);
     padding: 4px 10px;
     border-radius: 6px;
     font-size: 12px;
     cursor: pointer;
+    transition: var(--transition-fast);   /* ADD THIS */
+}
+
+
+.date-range-btn:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+    border-color: var(--accent-purple);
+}
+
+.date-range-btn:focus,
+.date-range-btn:focus-visible {
+    outline: none;
+    border-color: var(--accent-purple);
+    box-shadow: 0 0 0 3px rgba(6, 182, 212, 0.15);
 }
 .date-range-btn.active {
     background: var(--accent-purple);
@@ -1507,6 +1522,12 @@ html[data-theme="light"] .filter-select:hover {
     border-radius: 16px;
     padding: 28px;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.chart-actions {
+    display: flex;
+    gap: 8px;
+    align-items: center;
 }
 
 .chart-header {

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -91,6 +91,20 @@ html[data-theme="dark"] {
     
     --overlay: rgba(0, 0, 0, 0.8);
 }
+.date-range-btn {
+    background: transparent;
+    border: 1px solid var(--border-color);
+    color: var(--text-secondary);
+    padding: 4px 10px;
+    border-radius: 6px;
+    font-size: 12px;
+    cursor: pointer;
+}
+.date-range-btn.active {
+    background: var(--accent-purple);
+    color: white;
+    border-color: var(--accent-purple);
+}
 
 /* Light Theme - Clean */
 html[data-theme="light"] {

--- a/public/index.html
+++ b/public/index.html
@@ -320,13 +320,18 @@
                 <!-- Charts -->
                 <div class="charts-grid">
                     <div class="chart-card">
-                        <div class="chart-header">
-                            <h3>Clicks Over Time</h3>
-                            <div class="chart-actions">
-                                <button class="date-range-btn active" data-days="7">7D</button>
-                                <button class="date-range-btn" data-days="30">30D</button>
-                                <button class="date-range-btn" data-days="90">90D</button>
-                                <button class="date-range-btn" data-days="all">All</button>
+                            <div class="chart-header">
+                                <h3>Clicks Over Time</h3>
+                                <div class="chart-actions">
+                                    <button class="date-range-btn active" data-days="7">7D</button>
+                                    <button class="date-range-btn" data-days="30">30D</button>
+                                    <button class="date-range-btn" data-days="90">90D</button>
+                                    <button class="date-range-btn" data-days="all">All</button>
+                                </div>
+                            </div>
+                            <!-- THIS WAS MISSING -->
+                            <div class="chart-body">
+                                <canvas id="clicksChart"></canvas>
                             </div>
                         </div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -323,13 +323,12 @@
                         <div class="chart-header">
                             <h3>Clicks Over Time</h3>
                             <div class="chart-actions">
-                                <button class="btn-icon"><i class="fas fa-download"></i></button>
+                                <button class="date-range-btn active" data-days="7">7D</button>
+                                <button class="date-range-btn" data-days="30">30D</button>
+                                <button class="date-range-btn" data-days="90">90D</button>
+                                <button class="date-range-btn" data-days="all">All</button>
                             </div>
                         </div>
-                        <div class="chart-body">
-                            <canvas id="clicksChart"></canvas>
-                        </div>
-                    </div>
 
                     <div class="chart-card">
                         <div class="chart-header">

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2632,6 +2632,11 @@ async function loadAnalyticsData(linkFilter) {
         
         // Render charts and lists
         renderClicksChart(clicksOverTimeData);
+        const buttons = document.querySelectorAll('.date-range-btn');
+            buttons.forEach(btn => {
+                btn.classList.toggle('active', btn.dataset.days === 'all');
+});
+
         renderReferrersChart(topReferrers);
         renderGeographicList(geographicList);
         renderDevicesList(devicesList);

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -513,6 +513,12 @@ function initializeEventListeners() {
     
     // Initialize custom styled selects
     initializeCustomSelects();
+    document.querySelectorAll('.date-range-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+        const days = btn.dataset.days === 'all' ? 'all' : parseInt(btn.dataset.days);
+        filterClicksChart(days);
+    });
+});
 }
 
 // ================================
@@ -2543,6 +2549,7 @@ async function loadAnalyticsData(linkFilter) {
             const timeB = new Date(b.timestamp).getTime();
             return timeA - timeB;
         });
+        window._lastClicksOverTimeData = allClickHistory;
         
         // Calculate unique visitors from click history (approximate by counting unique referrer+device combinations)
         const visitorFingerprints = new Set();
@@ -2747,18 +2754,15 @@ function processClicksOverTime(clickHistory) {
 }
 
 function renderClicksChart(chartData) {
-    // Implement with Chart.js
     const ctx = document.getElementById('clicksChart');
     if (!ctx) return;
-    
-    // Destroy existing chart if any
+
     if (window.clicksChartInstance) {
         window.clicksChartInstance.destroy();
     }
-    
+
     const { labels, data, granularity } = chartData;
-    
-    // Create new chart
+
     window.clicksChartInstance = new Chart(ctx, {
         type: 'line',
         data: {
@@ -2775,16 +2779,8 @@ function renderClicksChart(chartData) {
         options: {
             responsive: true,
             maintainAspectRatio: false,
-            plugins: {
-                legend: {
-                    display: false
-                }
-            },
-            scales: {
-                y: {
-                    beginAtZero: true
-                }
-            }
+            plugins: { legend: { display: false } },
+            scales: { y: { beginAtZero: true } }
         }
     });
 }
@@ -3460,3 +3456,22 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 });
+
+function filterClicksChart(days) {
+    const raw = window._lastClicksOverTimeData;
+    if (!raw || raw.length === 0) return;
+
+    let filtered = raw;
+    if (days !== 'all') {
+        const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+        filtered = raw.filter(click => 
+            new Date(click.timestamp).getTime() >= cutoff
+        );
+    }
+
+    document.querySelectorAll('.date-range-btn').forEach(btn => {
+        btn.classList.toggle('active', btn.dataset.days === String(days));
+    });
+
+    renderClicksChart(processClicksOverTime(filtered));
+}


### PR DESCRIPTION
## Summary
Adds 7D / 30D / 90D / All time filter buttons to the "Clicks Over Time" 
chart on the Analytics dashboard.

## Changes
- `index.html` — Added filter buttons (7D, 30D, 90D, All) above the clicks chart
- `styles.css` — Added `.date-range-btn` styles matching existing glassmorphism UI
- `app.js` — Updated `renderClicksChart()` to filter by selected range, 
  stored raw click history on `window._lastClicksOverTimeData`, 
  wired up button click listeners in `initializeEventListeners()`

## How it works
Filters the existing `clickHistory` data already in memory — no new API 
calls or backend changes needed.

Closes #128 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Date-range filters added to the Analytics "Clicks Over Time" chart (7D, 30D, 90D, All); switching ranges updates the chart and it defaults to "All" on load.
  * Chart rendering refined: legend hidden and y-axis now starts at zero for clearer comparisons.

* **Style**
  * New styling for date-range controls with hover/focus and active states; chart action layout improved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->