### PR TITLE
fix: restrict CORS to known origins and add auth and rate limit to /api/bug-report

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,11 @@ GITHUB_TOKEN=your_github_personal_access_token
 PORT=3000
 BASE_URL=http://localhost:3000
 
+# CORS: comma-separated list of allowed frontend origins.
+# Defaults to https://piik.me if not set.
+# Example for multiple origins: https://piik.me,https://staging.piik.me
+ALLOWED_ORIGIN=https://piik.me
+
 # Upstash Redis Configuration (for Edge Redirects)
 # Get these from: https://console.upstash.com/
 # Create a Redis database and copy the REST API credentials

--- a/server.js
+++ b/server.js
@@ -14,6 +14,7 @@ const fetch = typeof globalThis.fetch === 'function'
   : (...args) => import('node-fetch').then(({ default: fetchFn }) => fetchFn(...args));
 const redisUtils = require('./src/utils/redis.utils');
 const redirectCache = require('./src/utils/redirect-cache.utils');
+const rateLimit = require('express-rate-limit');
 const { securityHeaders, apiLimiter } = require('./src/middleware/security.middleware');
 require('dotenv').config();
 
@@ -54,12 +55,34 @@ firebaseState.reason = 'Firebase connected successfully';
 const app = express();
 const isServerless = Boolean(process.env.VERCEL || process.env.AWS_LAMBDA_FUNCTION_NAME);
 const server = isServerless ? null : http.createServer(app);
+// Allowed origins: the production frontend and localhost for development.
+// Set ALLOWED_ORIGIN in the environment to override for custom deployments.
+const ALLOWED_ORIGINS = (process.env.ALLOWED_ORIGIN || 'https://piik.me')
+  .split(',')
+  .map((o) => o.trim())
+  .concat(['http://localhost:3000', 'http://localhost:3001']);
+
+const corsOptions = {
+  origin: (origin, callback) => {
+    // Allow requests with no origin (server-to-server, curl, mobile apps).
+    if (!origin || ALLOWED_ORIGINS.includes(origin)) {
+      callback(null, true);
+    } else {
+      callback(new Error('Not allowed by CORS'));
+    }
+  },
+  credentials: true,
+  methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+  allowedHeaders: ['Content-Type', 'Authorization'],
+};
+
 const io = isServerless
   ? { emit: () => {} }
   : socketIo(server, {
       cors: {
-        origin: "*",
-        methods: ["GET", "POST"]
+        origin: ALLOWED_ORIGINS,
+        methods: ['GET', 'POST'],
+        credentials: true,
       }
     });
 
@@ -78,7 +101,7 @@ function fromFirestoreId(firestoreId) {
 // Middleware
 app.use(securityHeaders);
 app.use(apiLimiter);
-app.use(cors());
+app.use(cors(corsOptions));
 app.use(express.json());
 app.use(express.static('public', { index: false }));
 app.use((req, res, next) => {
@@ -967,8 +990,25 @@ app.post('/api/track/share/:shortCode', async (req, res) => {
   res.json({ success: true, message: 'Shares tracked via UTM parameters' });
 });
 
-// Create GitHub Issue for Bug Report
-app.post('/api/bug-report', async (req, res) => {
+// Per-user rate limiter for bug reports: 3 submissions per hour.
+// Without this, any authenticated user can create unlimited GitHub issues
+// using the server's GITHUB_TOKEN, exhausting the API quota for everyone.
+const bugReportLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000, // 1 hour
+  max: 3,
+  keyGenerator: (req) => req.user?.uid || req.ip,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: {
+    success: false,
+    error: 'You can submit a maximum of 3 bug reports per hour. Please try again later.'
+  }
+});
+
+// Create GitHub Issue for Bug Report.
+// Requires authentication so anonymous callers cannot use the server's
+// GITHUB_TOKEN to create unlimited issues on the repository.
+app.post('/api/bug-report', verifyToken, bugReportLimiter, async (req, res) => {
   try {
     const { title, description, steps, email, userId, userEmail } = req.body;
     


### PR DESCRIPTION
## Summary

Two security issues are fixed in this PR.

**Issue #126 - Wildcard CORS:** `app.use(cors())` with no arguments returned `Access-Control-Allow-Origin: *` on every API response. This allowed any external website to make cross-origin requests to the API. The Socket.IO server also accepted connections from `origin: '*'`. Both are now restricted to an explicit origin allowlist.

**Issue #127 - Unauthenticated bug report endpoint:** `POST /api/bug-report` had no `verifyToken` middleware, allowing any anonymous caller to create GitHub issues on the repository using the server's `GITHUB_TOKEN`. With no rate limiting on this specific endpoint, a script could exhaust the GitHub API quota in seconds. The endpoint now requires a valid Firebase session and enforces 3 submissions per hour per user.

Closes #126
Closes #127

---

## Type of Change

- [x] Bug fix
- [x] Security

---

## What Changed

**`server.js`**

CORS before:
```js
app.use(cors());                           // allows all origins
socketIo(server, { cors: { origin: '*' } })
```

CORS after:
```js
const ALLOWED_ORIGINS = (process.env.ALLOWED_ORIGIN || 'https://piik.me')
  .split(',').map(o => o.trim())
  .concat(['http://localhost:3000', 'http://localhost:3001']);

app.use(cors(corsOptions));                // only listed origins
socketIo(server, { cors: { origin: ALLOWED_ORIGINS, credentials: true } })
```

Bug report before:
```js
app.post('/api/bug-report', async (req, res) => {
```

Bug report after:
```js
const bugReportLimiter = rateLimit({ windowMs: 3600000, max: 3, ... });
app.post('/api/bug-report', verifyToken, bugReportLimiter, async (req, res) => {
```

**`.env.example`**
- Documents the new `ALLOWED_ORIGIN` variable (defaults to `https://piik.me`).

---

## How to Test

1. From an unlisted origin, make a request to any API endpoint and confirm the response does not include `Access-Control-Allow-Origin`.
2. From `http://localhost:3000`, confirm normal API access works.
3. Call `POST /api/bug-report` without an `Authorization` header and confirm HTTP 401.
4. Call it with a valid token more than 3 times in an hour and confirm HTTP 429 on the fourth call.

---

## Checklist

- [x] No new `console.log` or debug statements.
- [x] Backward compatible: `ALLOWED_ORIGIN` defaults to `https://piik.me` if not set.
- [x] `express-rate-limit` is already a transitive dependency via `security.middleware`.