### PR TITLE
chore: add .editorconfig for consistent editor settings across contributors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,70 @@
+# EditorConfig — https://editorconfig.org
+# Top-most EditorConfig file
+root = true
+
+# ─── All Files ────────────────────────────────────────────────────────────────
+[*]
+charset                  = utf-8
+end_of_line              = lf
+indent_style             = space
+indent_size              = 2
+trim_trailing_whitespace = true
+insert_final_newline     = true
+
+# ─── JavaScript / Node.js ─────────────────────────────────────────────────────
+[*.{js,mjs,cjs}]
+indent_style = space
+indent_size  = 2
+
+# ─── JSON ─────────────────────────────────────────────────────────────────────
+[*.json]
+indent_style = space
+indent_size  = 2
+
+# ─── HTML ─────────────────────────────────────────────────────────────────────
+[*.html]
+indent_style = space
+indent_size  = 2
+
+# ─── CSS ──────────────────────────────────────────────────────────────────────
+[*.css]
+indent_style = space
+indent_size  = 2
+
+# ─── Markdown ─────────────────────────────────────────────────────────────────
+# Trailing whitespace is meaningful in Markdown (line breaks), so disable trim
+[*.md]
+trim_trailing_whitespace = false
+indent_size              = 2
+
+# ─── YAML ─────────────────────────────────────────────────────────────────────
+[*.{yml,yaml}]
+indent_style = space
+indent_size  = 2
+
+# ─── Environment & Config ─────────────────────────────────────────────────────
+[*.env*]
+insert_final_newline     = true
+trim_trailing_whitespace = true
+
+# ─── Package & Lock Files ─────────────────────────────────────────────────────
+[package.json]
+indent_size = 2
+
+[package-lock.json]
+indent_size = 2
+
+# ─── Vercel Config ────────────────────────────────────────────────────────────
+[vercel.json]
+indent_size = 2
+
+# ─── Shell Scripts ────────────────────────────────────────────────────────────
+[*.sh]
+indent_style = space
+indent_size  = 2
+end_of_line  = lf
+
+# ─── Makefiles ────────────────────────────────────────────────────────────────
+# Makefiles require tabs — do not override
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## Summary
Adds a `.editorconfig` file to the root of the repository to enforce consistent formatting across all editors and contributors.

**Rules applied:**
- 2-space indentation for all JS, JSON, HTML, CSS, YAML, and config files — matches the existing codebase style
- `lf` line endings enforced globally — prevents Windows/Mac/Linux conflicts
- `utf-8` charset across all files
- `insert_final_newline = true` — avoids noisy diffs from missing newlines
- `trim_trailing_whitespace = false` scoped to `.md` files — preserves intentional Markdown line breaks
- `Makefile` uses tabs — required by Make syntax

## Related Issue
Fixes #154 

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code style / formatting
- [ ] Refactor
- [x] Chore / maintenance

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide
- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
- [x] I have linked related issues
- [ ] I have included screenshots for UI changes (if applicable)

## Notes
- No code changes — configuration only.
- Works automatically in VS Code, IntelliJ, Vim, Neovim, Sublime Text, and any editor with EditorConfig support.
- Developers without an EditorConfig plugin will not be affected negatively — the file is simply ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added standardized code formatting configuration across the repository to ensure consistent code style and formatting conventions for all contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->