### PR TITLE
Fix issue #177

### DIFF
--- a/server.js
+++ b/server.js
@@ -534,8 +534,9 @@ app.get('/api/user/analytics', verifyToken, async (req, res) => {
 });
 
 // Get analytics for a short link
-app.get('/api/analytics/:shortCode', async (req, res) => {
+app.get('/api/analytics/:shortCode', verifyToken, async (req, res) => {
   const { shortCode } = req.params;
+  const userId = req.user.uid;
   
   try {
     // Try Firestore first
@@ -543,10 +544,15 @@ app.get('/api/analytics/:shortCode', async (req, res) => {
     const linkDoc = await db.collection(COLLECTIONS.LINKS).doc(firestoreId).get();
     
     if (linkDoc.exists) {
+      const linkData = linkDoc.data();
+      if (linkData.userId !== userId) {
+        return res.status(403).json({ error: 'Forbidden' });
+      }
+
       // Use aggregated analytics from shards
       const aggregatedStats = await getAggregatedAnalytics(firestoreId);
       return res.json({
-        link: linkDoc.data(),
+        link: linkData,
         analytics: aggregatedStats
       });
     }
@@ -560,6 +566,10 @@ app.get('/api/analytics/:shortCode', async (req, res) => {
   
   if (!link || !stats) {
     return res.status(404).json({ error: 'Link not found' });
+  }
+
+  if (link.userId !== userId) {
+    return res.status(403).json({ error: 'Forbidden' });
   }
 
   res.json({

--- a/server.js
+++ b/server.js
@@ -159,7 +159,7 @@ async function verifyToken(req, res, next) {
   const token = authHeader.split('Bearer ')[1];
   
   try {
-    const decodedToken = await auth.verifyIdToken(token);
+    const decodedToken = await auth.verifyIdToken(token, true);
     req.user = decodedToken;
     next();
   } catch (error) {


### PR DESCRIPTION

## Summary

Secured the analytics endpoint by adding authentication and ownership verification. The endpoint now requires a valid Firebase token and ensures that only the owner of a short link can access its analytics data.

## Related Issue

Fixes #177

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Code style / formatting
* [ ] Refactor
* [ ] Chore / maintenance

## Checklist

* [x] I have read the [[CONTRIBUTING.md](https://chatgpt.com/c/CONTRIBUTING.md)](CONTRIBUTING.md) guide
* [x] My code follows the project's coding standards
* [x] I have tested my changes locally
* [x] I have linked related issues
* [ ] I have included screenshots for UI changes (if applicable)

## Notes

### Changes Made

* Added `verifyToken` middleware to the `GET /api/analytics/:shortCode` route.
* Implemented ownership validation to ensure only the link owner can access analytics.
* Added proper `403 Forbidden` handling for unauthorized access attempts.
* Preserved existing functionality for authenticated owners.
* Improved protection of analytics and link metadata from unauthorized users.

### Security Impact

This fixes an access control vulnerability where analytics data for any short link could be retrieved without authentication. The endpoint now enforces both authentication and authorization before returning analytics data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Analytics endpoint now requires authentication to access.
  * Access is limited to the owner of a link; requests for others’ links are denied (403).
  * Token revocation is enforced so revoked sessions can no longer access analytics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->