### PR TITLE
fix: change hamburger icon to close icon and update aria-label when menu is open

### DIFF
--- a/public/js/landing.js
+++ b/public/js/landing.js
@@ -79,11 +79,15 @@ function initMobileMenu() {
             menu.classList.remove('translate-x-full');
             document.body.style.overflow = 'hidden';
             syncMenuState(true);
+            const icon = toggle.querySelector('i');
+            if (icon) icon.className = 'fas fa-times text-xl';
+            toggle.setAttribute('aria-label', 'Close mobile menu');
         } else {
             menu.classList.add('translate-x-full');
             document.body.style.overflow = '';
             const icon = toggle.querySelector('i');
             if (icon) icon.className = 'fas fa-bars text-xl';
+            toggle.setAttribute('aria-label', 'Open mobile menu');
         }
     }
 

--- a/public/js/landing.js
+++ b/public/js/landing.js
@@ -83,11 +83,13 @@ function initMobileMenu() {
             if (icon) icon.className = 'fas fa-times text-xl';
             toggle.setAttribute('aria-label', 'Close mobile menu');
         } else {
+            isOpen = false;
             menu.classList.add('translate-x-full');
             document.body.style.overflow = '';
             const icon = toggle.querySelector('i');
             if (icon) icon.className = 'fas fa-bars text-xl';
             toggle.setAttribute('aria-label', 'Open mobile menu');
+            syncMenuState(false);
         }
     }
 


### PR DESCRIPTION
Fixes #194

## Problem
When the mobile hamburger menu was opened:
- The icon remained as three bars (fa-bars) instead of changing to a close icon (fa-times)
- The aria-label stayed static as "Open mobile menu" instead of updating dynamically

## Fix
In the `toggleMenu()` function:
- Added icon class toggle: `fa-bars` ↔ `fa-times` based on menu state
- Added `aria-label` toggle: "Open mobile menu" ↔ "Close mobile menu"

## Testing
- Opened site on mobile view (< 768px)
- Clicked hamburger → icon changes to ✕ and aria-label updates to "Close mobile menu"
- Clicked again → icon reverts to ☰ and aria-label updates to "Open mobile menu"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mobile menu toggle now reliably switches its icon between open and close states, giving clearer visual feedback when the menu is opened or closed.
  * Accessibility text (aria-label) for the toggle updates on open and close, improving screen reader announcements and overall keyboard/screen-reader navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->