### PR TITLE
fix: add morgan HTTP request logging middleware

### DIFF
--- a/server.js
+++ b/server.js
@@ -83,7 +83,7 @@ function fromFirestoreId(firestoreId) {
 }
 
 // Middleware
-app.use(morgan('combined'));
+app.use(morgan(':method :url :status :res[content-length] - :response-time ms'));
 app.use(securityHeaders);
 app.use(apiLimiter);
 // Restrict CORS to the configured application origin.

--- a/server.js
+++ b/server.js
@@ -17,6 +17,7 @@ const redisUtils = require('./src/utils/redis.utils');
 const redirectCache = require('./src/utils/redirect-cache.utils');
 const { securityHeaders, apiLimiter, bugReportLimiter } = require('./src/middleware/security.middleware');
 const splitTestService = require('./src/services/splitTest.service');
+const morgan = require('morgan');
 require('dotenv').config();
 
 // Initialize Firebase Admin
@@ -82,6 +83,7 @@ function fromFirestoreId(firestoreId) {
 }
 
 // Middleware
+app.use(morgan('combined'));
 app.use(securityHeaders);
 app.use(apiLimiter);
 // Restrict CORS to the configured application origin.


### PR DESCRIPTION
## Summary
`morgan` was already installed in `package.json` but was never imported or registered as middleware in `server.js`. This meant no HTTP access logs were being generated in production, making it impossible to debug request-level issues without adding extra instrumentation.

The fix adds two lines to `server.js`:
- `const morgan = require('morgan');` at the top with other imports
- `app.use(morgan('combined'));` early in the middleware chain before route handlers

Every HTTP request will now produce a structured log line like:
`GET /api/user/links 200 45ms`

## Related Issue
Fixes #204

## Type of Change
- [x] Bug fix

## Checklist
- [x] I have read the CONTRIBUTING.md guide
- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
- [x] I have linked related issues

## Notes
No new dependencies introduced — `morgan` was already present in `package.json`. Fix is exactly two lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adds detailed HTTP request logging on the server. Request entries now include method, URL, status, content length and response time, producing more comprehensive server logs for incoming traffic. No other public APIs or routing behavior were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->