### PR TITLE
feat: add PATCH /api/links/:shortCode endpoint to edit link metadata

### DIFF
--- a/server.js
+++ b/server.js
@@ -1273,11 +1273,22 @@ app.patch('/api/links/:shortCode', verifyToken, async (req, res) => {
     const updateData = {};
     if (title !== undefined) updateData.title = title;
     if (notes !== undefined) updateData.notes = notes;
-    if (tags !== undefined) updateData.tags = Array.isArray(tags) ? tags : [];
+    if (tags !== undefined) {
+      if (!Array.isArray(tags)) {
+        return res.status(400).json({ error: 'tags must be an array' });
+      }
+      updateData.tags = tags;
+    }
     if (expiresAt !== undefined) {
-      updateData.expiresAt = expiresAt
-        ? admin.firestore.Timestamp.fromDate(new Date(expiresAt))
-        : null;
+      if (expiresAt !== null) {
+        const parsed = new Date(expiresAt);
+        if (isNaN(parsed.getTime())) {
+          return res.status(400).json({ error: 'expiresAt must be a valid ISO date string' });
+        }
+        updateData.expiresAt = admin.firestore.Timestamp.fromDate(parsed);
+      } else {
+        updateData.expiresAt = null;
+      }
     }
 
     await linkRef.update(updateData);

--- a/server.js
+++ b/server.js
@@ -1244,6 +1244,54 @@ app.delete('/api/links/:shortCode', verifyToken, async (req, res) => {
   }
 });
 
+// Edit link metadata (title, notes, tags, expiresAt)
+app.patch('/api/links/:shortCode', verifyToken, async (req, res) => {
+  let { shortCode } = req.params;
+  shortCode = decodeURIComponent(shortCode);
+  const userId = req.user.uid;
+  const { title, notes, tags, expiresAt } = req.body;
+
+  if (title === undefined && notes === undefined && tags === undefined && expiresAt === undefined) {
+    return res.status(400).json({ error: 'At least one field (title, notes, tags, expiresAt) must be provided' });
+  }
+
+  try {
+    const firestoreId = toFirestoreId(shortCode);
+    const linkRef = db.collection(COLLECTIONS.LINKS).doc(firestoreId);
+    const linkDoc = await linkRef.get();
+
+    if (!linkDoc.exists) {
+      return res.status(404).json({ error: 'Link not found' });
+    }
+
+    const linkData = linkDoc.data();
+
+    if (linkData.userId !== userId) {
+      return res.status(403).json({ error: 'You do not have permission to edit this link' });
+    }
+
+    const updateData = {};
+    if (title !== undefined) updateData.title = title;
+    if (notes !== undefined) updateData.notes = notes;
+    if (tags !== undefined) updateData.tags = Array.isArray(tags) ? tags : [];
+    if (expiresAt !== undefined) {
+      updateData.expiresAt = expiresAt
+        ? admin.firestore.Timestamp.fromDate(new Date(expiresAt))
+        : null;
+    }
+
+    await linkRef.update(updateData);
+
+    await redisUtils.deleteLinkFromRedis(shortCode);
+    await redirectCache.delete(shortCode);
+
+    res.json({ success: true, message: 'Link updated successfully' });
+  } catch (error) {
+    console.error('Error updating link:', error);
+    res.status(500).json({ error: 'Failed to update link' });
+  }
+});
+
 // Configure split-test for a link
 app.post('/api/links/:shortCode/split-test', verifyToken, async (req, res) => {
   let { shortCode } = req.params;


### PR DESCRIPTION
## Summary
Users had no way to update link metadata (title, notes, tags, expiresAt) after creation. The only workaround was to delete and recreate the link, which permanently lost all analytics history.

This adds a new authenticated `PATCH /api/links/:shortCode` endpoint that accepts a partial update body with any combination of `title`, `notes`, `tags`, and `expiresAt`. It verifies token and ownership before applying the update, only modifies fields present in the request body, and clears Redis and redirect cache so changes take effect immediately.

## Related Issue
Fixes #205

## Type of Change
- [x] New feature

## Checklist
- [x] I have read the CONTRIBUTING.md guide
- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
- [x] I have linked related issues

## Notes
The Firestore data model already stores all these fields. The `verifyToken` middleware and ownership-check pattern follow the same approach used by all other authenticated endpoints in `server.js`. No schema changes needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authors can edit link metadata (title, notes, tags, expiration date) for existing shortened links.
  * Changes take effect immediately for future redirects.

* **Bug Fixes / Validation**
  * Validates tags format and expiration values; explicitly clearing expiration is supported.
  * Unauthorized or non-existent link edits return appropriate errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->