### PR TITLE
fix: switch pull_request to pull_request_target in auto-label workflow

### DIFF
--- a/.github/workflows/issue-auto-label.yml
+++ b/.github/workflows/issue-auto-label.yml
@@ -3,7 +3,7 @@ name: Auto-label new issues and pull requests
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 permissions:


### PR DESCRIPTION
## Summary

Fix auto-label workflow 403 error on fork PRs by changing `pull_request` trigger to `pull_request_target`.

When a PR is opened from a forked repository, the default `GITHUB_TOKEN` is read-only regardless of the `permissions:` block in the workflow YAML. The `pull_request` event causes `actions/github-script@v7` to fail with `403 — Resource not accessible by integration` when calling `github.rest.issues.addLabels()`.

`pull_request_target` runs in the base repository's context, honoring the declared `issues: write` and `pull-requests: write` permissions. This workflow is safe for this change because it does not checkout, install, or execute any code from the PR — it only reads the title/body from the event payload and calls the GitHub Labels API.

## Related Issue

Fixes #212

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code style / formatting
- [ ] Refactor
- [ ] Chore / maintenance

## Checklist

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide
- [X] My code follows the project's coding standards
- [X] I have tested my changes locally
- [X] I have linked related issues
- [ ] I have included screenshots for UI changes (if applicable)

## Notes

The change is a single-line diff in `.github/workflows/issue-auto-label.yml`:

```diff
-  pull_request:
+  pull_request_target:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for issue and pull request auto-labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->