### PR TITLE
fix: update bug report endpoint from Link360 to piik.me

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -3703,7 +3703,7 @@ document.addEventListener('DOMContentLoaded', () => {
             
             if (suggestion) {
                 // Redirect to GitHub discussions with pre-filled title
-                const discussionUrl = `https://github.com/xthxr/Link360/discussions/new?category=ideas&title=${encodeURIComponent(suggestion)}`;
+                const discussionUrl = `https://github.com/xthxr/piik.me/discussions/new?category=ideas&title=${encodeURIComponent(suggestion)}`;
                 window.open(discussionUrl, '_blank');
                 
                 // Clear input

--- a/server.js
+++ b/server.js
@@ -1504,14 +1504,14 @@ app.post('/api/bug-report', verifyToken, bugReportLimiter, async (req, res) => {
     issueBody += `- Timestamp: ${new Date().toISOString()}\n`;
     
     // Create GitHub issue using fetch
-    const response = await fetch('https://api.github.com/repos/xthxr/Link360/issues', {
+    const response = await fetch('https://api.github.com/repos/xthxr/piik.me/issues', {
       method: 'POST',
       headers: {
         'Accept': 'application/vnd.github+json',
         'Authorization': `Bearer ${process.env.GITHUB_TOKEN}`,
         'X-GitHub-Api-Version': '2022-11-28',
         'Content-Type': 'application/json',
-        'User-Agent': 'Link360-Bug-Reporter'
+        'User-Agent': 'piik.me-Bug-Reporter'
       },
       body: JSON.stringify({
         title: `[Bug Report] ${title}`,


### PR DESCRIPTION
Fixes #246

The `/api/bug-report` endpoint was hardcoded to `xthxr/Link360` — returns 404 since the repo was renamed to `piik.me`.

## Changes
- `server.js`: GitHub API URL and User-Agent updated to `xthxr/piik.me`
- `public/js/app.js`: Feature suggestion discussions URL updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bug report and feature suggestion endpoints to route feedback to the correct GitHub repository.
  * Corrected application identification headers for bug report submissions to GitHub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->