### PR TITLE
[BUG] URL preview does not validate Content-Type before parsing the response body as HTML, causing crashes on binary file URLs (#261)

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,3 +540,4 @@ Built with amazing open-source technologies:
 Made with ❤️ by [xthxr](https://github.com/xthxr)
 
 </div>
+# TODO: [bug] url preview does not validate content-type before parsing the response body as html, causing crashes on binary file urls (#261)


### PR DESCRIPTION
Fixes #261

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new TODO note in the README highlighting a known issue with URL previews when binary files are encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->