### PR TITLE
fix: remove unused variables and catch binding parameters

### DIFF
--- a/config/firebase.config.js
+++ b/config/firebase.config.js
@@ -23,7 +23,7 @@ function initializeFirebase() {
     console.log('✅ Firebase Admin initialized');
     isInitialized = true;
     return true;
-  } catch (error) {
+  } catch {
     console.log('⚠️  Firebase Admin not configured. Using in-memory storage.');
     console.log('   See docs/FIREBASE_SETUP.md for setup instructions.');
     return false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -188,7 +188,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -230,7 +229,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -513,7 +511,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.4.tgz",
       "integrity": "sha512-pUxEGmR+uu21OG/icAovjlu1fcYJzyVhhT0rsCrn+zi+nHtrS43Bp9KPn9KGa4NMspCUE++nkyiqziuIvJdwzw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -580,7 +577,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.4.tgz",
       "integrity": "sha512-T7ifGmb+awJEcp542Ek4HtNfBxcBrnuk1ggUdqyFEdsXHdq7+wVlhvE6YukTL7NS8hIkEfL7TMAPx/uCNqt30g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.4",
         "@firebase/component": "0.7.0",
@@ -596,8 +592,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth": {
       "version": "1.11.0",
@@ -1048,7 +1043,6 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -3036,7 +3030,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -5927,8 +5920,7 @@
       "version": "0.181.2",
       "resolved": "https://registry.npmjs.org/three/-/three-0.181.2.tgz",
       "integrity": "sha512-k/CjiZ80bYss6Qs7/ex1TBlPD11whT9oKfT8oTGiHa34W4JRd1NiH/Tr1DbHWQ2/vMUypxksLnF2CfmlmM5XFQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/three-conic-polygon-geometry": {
       "version": "2.1.2",

--- a/server.js
+++ b/server.js
@@ -68,7 +68,7 @@ firebaseState.reason = 'Firebase connected successfully';
 
   
   console.log('✅ Firebase Admin initialized');
-} catch (error) {
+} catch {
   console.log('⚠️ Firebase Admin not configured. Using in-memory storage.');
   console.log('   See FIREBASE_SETUP.md for setup instructions.');
 }
@@ -93,12 +93,6 @@ const io = isServerless
 // Firestore document IDs cannot contain '/' so we replace with '_'
 function toFirestoreId(shortCode) {
   return shortCode.replace(/\//g, '_');
-}
-
-// Helper function to convert Firestore ID back to shortCode
-function fromFirestoreId(firestoreId) {
-  // Keep as-is, shortCode field in the document has the original format
-  return firestoreId;
 }
 
 // Middleware
@@ -132,7 +126,7 @@ const COLLECTIONS = {
 // Helper to aggregate distributed analytics shards
 async function getAggregatedAnalytics(firestoreId) {
   const baseDoc = await db.collection(COLLECTIONS.ANALYTICS).doc(firestoreId).get();
-  let data = baseDoc.exists ? baseDoc.data() : {};
+  const data = baseDoc.exists ? baseDoc.data() : {};
 
   try {
     const shardsSnapshot = await db.collection(COLLECTIONS.ANALYTICS).doc(firestoreId).collection('shards').get();
@@ -220,7 +214,7 @@ function parseUTMParams(url) {
       term: urlObj.searchParams.get('utm_term') || '',
       content: urlObj.searchParams.get('utm_content') || ''
     };
-  } catch (e) {
+  } catch {
     return null;
   }
 }
@@ -235,7 +229,7 @@ function addUTMParams(url, utmParams) {
     if (utmParams.term) urlObj.searchParams.set('utm_term', utmParams.term);
     if (utmParams.content) urlObj.searchParams.set('utm_content', utmParams.content);
     return urlObj.toString();
-  } catch (e) {
+  } catch {
     return null;
   }
 }
@@ -350,7 +344,7 @@ app.post('/api/shorten', verifyToken, async (req, res) => {
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
       return res.status(400).json({ error: 'Only http and https URLs are allowed' });
     }
-  } catch (e) {
+  } catch {
     return res.status(400).json({ error: 'Invalid URL' });
   }
 
@@ -422,7 +416,7 @@ app.post('/api/shorten', verifyToken, async (req, res) => {
       finalUrl = urlWithUTM;
     }
   }
-  const healthData = await checkLinkHealth(finalUrl);
+  await checkLinkHealth(finalUrl);
   const baseUrl = getBaseUrl(req);
   const shortUrl = `${baseUrl}/${shortCode}`;
   
@@ -544,7 +538,7 @@ app.get('/api/user/analytics', verifyToken, async (req, res) => {
           linkData: link,
           analytics: analyticsDoc.exists ? analyticsDoc.data() : null
         };
-      } catch (err) {
+      } catch {
         return { shortCode: link.shortCode, linkData: link, analytics: null };
       }
     });
@@ -1474,7 +1468,6 @@ app.post('/api/track/impression/:shortCode', async (req, res) => {
 // Track share (deprecated - now tracked automatically via UTM parameters)
 // Keeping endpoint for backward compatibility but shares are counted on click with UTM
 app.post('/api/track/share/:shortCode', async (req, res) => {
-  const { shortCode } = req.params;
   // Shares are now tracked automatically when links with utm_source are clicked
   // No need to manually increment here
   res.json({ success: true, message: 'Shares tracked via UTM parameters' });
@@ -1693,7 +1686,7 @@ function getReferrerSource(req) {
       else if (hostname.includes('discord')) referrerSource = 'Discord';
       else if (hostname.includes('slack')) referrerSource = 'Slack';
       else referrerSource = hostname;
-    } catch (e) {
+    } catch {
       referrerSource = httpReferrer;
     }
   } else {

--- a/src/middleware/error.middleware.js
+++ b/src/middleware/error.middleware.js
@@ -1,4 +1,4 @@
-const errorHandler = (err, req, res, next) => {
+const errorHandler = (err, req, res, _next) => {
   console.error(err.stack);
   res.status(err.status || 500).json({
     success: false,

--- a/src/utils/checkLinkHealth.js
+++ b/src/utils/checkLinkHealth.js
@@ -13,7 +13,7 @@ async function checkLinkHealth(url) {
         maxRedirects: 5,
         validateStatus: () => true,
       });
-    } catch (headError) {
+    } catch {
       // Fallback to GET request
       response = await axios.get(url, {
         timeout: 5000,

--- a/src/utils/redirect-cache.utils.js
+++ b/src/utils/redirect-cache.utils.js
@@ -40,7 +40,7 @@ async function getRedisValue(shortCode) {
     if (typeof value === 'string') {
       try {
         return JSON.parse(value);
-      } catch (error) {
+      } catch {
         return value;
       }
     }

--- a/src/utils/url.utils.js
+++ b/src/utils/url.utils.js
@@ -24,7 +24,7 @@ function parseUTMParams(url) {
       term: urlObj.searchParams.get('utm_term') || '',
       content: urlObj.searchParams.get('utm_content') || ''
     };
-  } catch (e) {
+  } catch {
     return null;
   }
 }
@@ -44,7 +44,7 @@ function addUTMParams(url, utmParams) {
     if (utmParams.term) urlObj.searchParams.set('utm_term', utmParams.term);
     if (utmParams.content) urlObj.searchParams.set('utm_content', utmParams.content);
     return urlObj.toString();
-  } catch (e) {
+  } catch {
     return null;
   }
 }
@@ -96,7 +96,7 @@ function isValidUrl(url) {
   try {
     new URL(url);
     return true;
-  } catch (e) {
+  } catch {
     return false;
   }
 }


### PR DESCRIPTION
## Summary

Resolves no-unused-vars and prefer-const warnings across server-side code.

### Changes:
1. **config/firebase.config.js**: Removed unused `error` binding from catch
2. **src/middleware/error.middleware.js**: Prefix unused `next` param with `_`
3. **src/utils/checkLinkHealth.js**: Removed unused `headError` binding from catch
4. **src/utils/redirect-cache.utils.js**: Removed unused `error` binding from catch
5. **src/utils/url.utils.js**: Removed unused `e` binding from 3 catch blocks
6. **server.js**: 
   - Removed unused `fromFirestoreId` function (dead code)
   - Changed `let data` to `const data` (never reassigned)
   - Removed unused `healthData` variable assignment
   - Removed unused `shortCode` param destructuring in deprecated endpoint
   - Removed unused `error`/`e` bindings from 3 catch blocks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up internal error handling across several app flows.
  * Simplified URL validation, tracking, analytics, and cache parsing logic without changing user-facing behavior.
  * Improved code consistency in startup, middleware, and redirect/link-check routines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->