### PR TITLE
fix: route login and register to auth flow

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -228,6 +228,12 @@ function initializeNavigation() {
     // Load initial page based on URL
     const initialPath = window.location.pathname;
     const initialPage = initialPath.substring(1) || 'home';
+
+    if (initialPage === 'login' || initialPage === 'register') {
+        showLoginModal();
+        return;
+    }
+
     navigateToPage(initialPage, false);
 }
 

--- a/server.js
+++ b/server.js
@@ -1609,7 +1609,7 @@ app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'landing.html'));
 });
 
-app.get(['/home', '/analytics', '/profile', '/qr-generator', '/bio-link', '/dashboard'], (req, res) => {
+app.get(['/login', '/register', '/home', '/analytics', '/profile', '/qr-generator', '/bio-link', '/dashboard'], (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
 


### PR DESCRIPTION
Closes #273

## Summary
- serve the application shell for `/login` and `/register` instead of treating them as short-link codes
- open the existing Google authentication modal when either route is loaded

## Validation
- `node --check server.js`
- `node --check public/js/app.js`
- `npm run lint` (0 errors; existing warnings only)
- `git diff --check`
- local HTTP smoke test: `/login` and `/register` both returned `200` with `loginModal` present


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed direct visits to `/login` and `/register` so they open the login modal correctly.
  * Updated route handling to load these pages through the application interface.
  * Corrected a minor script structure issue to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->