### PR TITLE
fix: updateLinkInRedis always resets TTL to 365 days, ignoring original

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -3703,7 +3703,7 @@ document.addEventListener('DOMContentLoaded', () => {
             
             if (suggestion) {
                 // Redirect to GitHub discussions with pre-filled title
-                const discussionUrl = `https://github.com/xthxr/Link360/discussions/new?category=ideas&title=${encodeURIComponent(suggestion)}`;
+                const discussionUrl = `https://github.com/xthxr/piik.me/discussions/new?category=ideas&title=${encodeURIComponent(suggestion)}`;
                 window.open(discussionUrl, '_blank');
                 
                 // Clear input

--- a/server.js
+++ b/server.js
@@ -1504,14 +1504,14 @@ app.post('/api/bug-report', verifyToken, bugReportLimiter, async (req, res) => {
     issueBody += `- Timestamp: ${new Date().toISOString()}\n`;
     
     // Create GitHub issue using fetch
-    const response = await fetch('https://api.github.com/repos/xthxr/Link360/issues', {
+    const response = await fetch('https://api.github.com/repos/xthxr/piik.me/issues', {
       method: 'POST',
       headers: {
         'Accept': 'application/vnd.github+json',
         'Authorization': `Bearer ${process.env.GITHUB_TOKEN}`,
         'X-GitHub-Api-Version': '2022-11-28',
         'Content-Type': 'application/json',
-        'User-Agent': 'Link360-Bug-Reporter'
+        'User-Agent': 'piik.me-Bug-Reporter'
       },
       body: JSON.stringify({
         title: `[Bug Report] ${title}`,

--- a/src/utils/redis.utils.js
+++ b/src/utils/redis.utils.js
@@ -79,8 +79,9 @@ async function updateLinkInRedis(shortCode, updates) {
     // Merge updates
     const updated = { ...existing, ...updates };
     
-    // Store updated data (keep original TTL by re-storing with 1 year)
-    await client.setex(linkKey, 60 * 60 * 24 * 365, updated);
+    // Store updated data (preserve original TTL)
+    const ttl = await client.ttl(linkKey);
+    await client.setex(linkKey, ttl > 0 ? ttl : 60 * 60 * 24 * 365, updated);
     
     console.log(`✅ Updated link in Redis: ${shortCode}`);
     return true;


### PR DESCRIPTION
When a link was updated, the original TTL was always overwritten with a hardcoded 365 days. Changed to preserve the original TTL by reading it with client.ttl() before updating, falling back to 365 days only if the key has no TTL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Suggestions now open discussions in the correct repository.
  - Bug reports are submitted to the correct repository.
  - Updating an existing link now preserves its remaining expiration time instead of resetting it to one year.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->