### PR TITLE
fix: resolve 1 bugs

### DIFF
--- a/src/services/splitTest.service.js
+++ b/src/services/splitTest.service.js
@@ -36,7 +36,7 @@ function validateVariants(variants) {
     const v = variants[i];
 
     // label ----------------------------------------------------------------
-    if (typeof v.label !== 'string' || v.label.trim() === '') {
+    if (typeof v.label !== 'string' || v.label.trim().length === 0) {
       return { valid: false, message: `Variant at index ${i}: \`label\` must be a non-empty string.` };
     }
     const label = v.label.trim();
@@ -46,7 +46,7 @@ function validateVariants(variants) {
     labels.add(label.toLowerCase());
 
     // url ------------------------------------------------------------------
-    if (typeof v.url !== 'string' || v.url.trim() === '') {
+    if (typeof v.url !== 'string' || v.url.trim().length === 0) {
       return { valid: false, message: `Variant "${label}": \`url\` must be a non-empty string.` };
     }
     try {

--- a/src/services/splitTest.service.js
+++ b/src/services/splitTest.service.js
@@ -134,7 +134,7 @@ function buildVariantClickFields(variantLabel) {
  * @returns {Array<{ label: string, url: string, weight: number }>}
  */
 function normaliseVariants(variants) {
-  return variants.map((v) => ({
+  return (variants ?? []).map((v) => ({
     label: v.label.trim(),
     url: v.url.trim(),
     weight: Math.round(v.weight),


### PR DESCRIPTION
## Description
This PR fixes real bugs found in the codebase:

- Added null-safety guard: `.map()` on an undefined collection threw `TypeError`; now falls back to `[]`.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## How Has This Been Tested?
- [x] Local manual testing

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review

## Related Issue
Ref: #342


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for labels and URLs containing leading or trailing whitespace.
  * Improved handling of missing variant data to prevent validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->