### PR TITLE
[Security]: Add rate limiting via express-rate-limit to the /api/...

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "dompurify": "^3.3.1",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
-        "express-rate-limit": "^8.5.2",
+        "express-rate-limit": "^8.6.2",
         "firebase": "^12.4.0",
         "firebase-admin": "^13.6.0",
         "globe.gl": "^2.45.0",
@@ -188,7 +188,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -230,7 +229,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -513,7 +511,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.4.tgz",
       "integrity": "sha512-pUxEGmR+uu21OG/icAovjlu1fcYJzyVhhT0rsCrn+zi+nHtrS43Bp9KPn9KGa4NMspCUE++nkyiqziuIvJdwzw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -580,7 +577,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.4.tgz",
       "integrity": "sha512-T7ifGmb+awJEcp542Ek4HtNfBxcBrnuk1ggUdqyFEdsXHdq7+wVlhvE6YukTL7NS8hIkEfL7TMAPx/uCNqt30g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.4",
         "@firebase/component": "0.7.0",
@@ -596,8 +592,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth": {
       "version": "1.11.0",
@@ -1048,7 +1043,6 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -3036,7 +3030,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -3079,11 +3072,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
       "license": "MIT",
       "dependencies": {
+        "debug": "^4.4.3",
         "ip-address": "^10.2.0"
       },
       "engines": {
@@ -3095,6 +3089,29 @@
       "peerDependencies": {
         "express": ">= 4.11"
       }
+    },
+    "node_modules/express-rate-limit/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/express-rate-limit/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -5927,8 +5944,7 @@
       "version": "0.181.2",
       "resolved": "https://registry.npmjs.org/three/-/three-0.181.2.tgz",
       "integrity": "sha512-k/CjiZ80bYss6Qs7/ex1TBlPD11whT9oKfT8oTGiHa34W4JRd1NiH/Tr1DbHWQ2/vMUypxksLnF2CfmlmM5XFQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/three-conic-polygon-geometry": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dompurify": "^3.3.1",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
-    "express-rate-limit": "^8.5.2",
+    "express-rate-limit": "^8.6.2",
     "firebase": "^12.4.0",
     "firebase-admin": "^13.6.0",
     "globe.gl": "^2.45.0",

--- a/server.js
+++ b/server.js
@@ -15,7 +15,7 @@ const fetch = typeof globalThis.fetch === 'function'
 const checkLinkHealth = require('./src/utils/checkLinkHealth');
 const redisUtils = require('./src/utils/redis.utils');
 const redirectCache = require('./src/utils/redirect-cache.utils');
-const { securityHeaders, apiLimiter, bugReportLimiter } = require('./src/middleware/security.middleware');
+const { securityHeaders, apiLimiter, bugReportLimiter, createLimiter, trackLimiter } = require('./src/middleware/security.middleware');
 const splitTestService = require('./src/services/splitTest.service');
 require('dotenv').config();
 
@@ -326,7 +326,7 @@ function getBaseUrl(req) {
 }
 
 // Create short link (requires authentication)
-app.post('/api/shorten', verifyToken, async (req, res) => {
+app.post('/api/shorten', createLimiter, verifyToken, async (req, res) => {
   const {
   url,
   utmParams,
@@ -1422,7 +1422,7 @@ app.delete('/api/links/:shortCode/split-test', verifyToken, async (req, res) => 
 });
 
 // Track impression (when analytics page is viewed)
-app.post('/api/track/impression/:shortCode', async (req, res) => {
+app.post('/api/track/impression/:shortCode', trackLimiter, async (req, res) => {
   let { shortCode } = req.params;
   shortCode = decodeURIComponent(shortCode);
   
@@ -1473,7 +1473,7 @@ app.post('/api/track/impression/:shortCode', async (req, res) => {
 
 // Track share (deprecated - now tracked automatically via UTM parameters)
 // Keeping endpoint for backward compatibility but shares are counted on click with UTM
-app.post('/api/track/share/:shortCode', async (req, res) => {
+app.post('/api/track/share/:shortCode', trackLimiter, async (req, res) => {
   const { shortCode } = req.params;
   // Shares are now tracked automatically when links with utm_source are clicked
   // No need to manually increment here

--- a/src/middleware/security.middleware.js
+++ b/src/middleware/security.middleware.js
@@ -82,4 +82,36 @@ const bugReportLimiter = rateLimit({
     }
 });
 
-module.exports = { securityHeaders, apiLimiter, bugReportLimiter };
+/**
+ * Rate limiter for creating short links.
+ *
+ * /api/shorten requires verifyToken, so every request that reaches this limiter already
+ * carries an Authorization header -- a skip-if-authenticated rule would exempt every real
+ * request and rate-limit nothing. Applied by IP to every request instead.
+ */
+const createLimiter = rateLimit({
+    windowMs: 60 * 60 * 1000, // 1 hour
+    max: 10, // limit each IP to 10 requests per windowMs
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: {
+        success: false,
+        error: 'Too many short links created from this IP, please try again after an hour'
+    }
+});
+
+/**
+ * Rate limiter for analytics tracking.
+ */
+const trackLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 tracking requests per windowMs
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: {
+        success: false,
+        error: 'Too many requests from this IP, please try again after 15 minutes'
+    }
+});
+
+module.exports = { securityHeaders, apiLimiter, bugReportLimiter, createLimiter, trackLimiter };


### PR DESCRIPTION
Fixes #304

Add rate limiting to /api/shorten and /api/track endpoints via express-rate-limit; fixed the createLimiter's skip condition, which exempted every authenticated request (the only kind /api/shorten ever receives) and rate-limited nothing.

**Testing:** No automated test suite in this repo; verified by reading verifyToken (always requires the header createLimiter was skipping on) and confirming the limiter now applies uniformly.

---

## Summary

Brief description of the changes.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code style / formatting
- [ ] Refactor
- [ ] Chore / maintenance

## Checklist

- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide
- [ ] My code follows the project's coding standards
- [ ] I have tested my changes locally
- [ ] I have linked related issues
- [ ] I have included screenshots for UI changes (if applicable)

## Notes

Any additional context or notes for reviewers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection against excessive short-link creation requests.
  * Added safeguards against unusually high volumes of impression and share tracking activity.
  * Helps maintain service availability and more consistent performance during traffic spikes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->