### PR TITLE
Feature: Add Password-Protected Private Links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@upstash/redis": "^1.36.0",
         "@vercel/analytics": "^1.6.1",
         "axios": "^1.13.2",
+        "bcryptjs": "^3.0.3",
         "cors": "^2.8.5",
         "d3-scale": "^4.0.2",
         "d3-scale-chromatic": "^3.1.0",
@@ -188,7 +189,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -230,7 +230,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -513,7 +512,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.4.tgz",
       "integrity": "sha512-pUxEGmR+uu21OG/icAovjlu1fcYJzyVhhT0rsCrn+zi+nHtrS43Bp9KPn9KGa4NMspCUE++nkyiqziuIvJdwzw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -580,7 +578,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.4.tgz",
       "integrity": "sha512-T7ifGmb+awJEcp542Ek4HtNfBxcBrnuk1ggUdqyFEdsXHdq7+wVlhvE6YukTL7NS8hIkEfL7TMAPx/uCNqt30g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.4",
         "@firebase/component": "0.7.0",
@@ -596,8 +593,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth": {
       "version": "1.11.0",
@@ -1048,7 +1044,6 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -1890,6 +1885,15 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
     },
     "node_modules/bidi-js": {
       "version": "1.0.3",
@@ -3036,7 +3040,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -5927,8 +5930,7 @@
       "version": "0.181.2",
       "resolved": "https://registry.npmjs.org/three/-/three-0.181.2.tgz",
       "integrity": "sha512-k/CjiZ80bYss6Qs7/ex1TBlPD11whT9oKfT8oTGiHa34W4JRd1NiH/Tr1DbHWQ2/vMUypxksLnF2CfmlmM5XFQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/three-conic-polygon-geometry": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@upstash/redis": "^1.36.0",
     "@vercel/analytics": "^1.6.1",
     "axios": "^1.13.2",
+    "bcryptjs": "^3.0.3",
     "cors": "^2.8.5",
     "d3-scale": "^4.0.2",
     "d3-scale-chromatic": "^3.1.0",

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const http = require('http');
 const socketIo = require('socket.io');
 const cors = require('cors');
 const path = require('path');
+const bcrypt = require('bcryptjs');
 const { nanoid } = require('nanoid');
 const admin = require('firebase-admin');
 // Use the native fetch when available (Node 18+); fall back to node-fetch for
@@ -333,7 +334,10 @@ app.post('/api/shorten', verifyToken, async (req, res) => {
   customShortCode,
   username,
   notes,
-  tags
+  tags,
+  password,
+  passwordHint,
+  passwordLimit
 } = req.body;
   const userId = req.user.uid;
   
@@ -429,6 +433,11 @@ app.post('/api/shorten', verifyToken, async (req, res) => {
   // Store link data
   const { expiresAt, maxClicks } = req.body;
 
+  let passwordHash = null;
+  if (password) {
+    passwordHash = await bcrypt.hash(password, 10);
+  }
+
   const linkData = {
   originalUrl: finalUrl,
   shortCode,
@@ -438,6 +447,10 @@ app.post('/api/shorten', verifyToken, async (req, res) => {
 
   notes: notes || '',
   tags: Array.isArray(tags) ? tags : [],
+  passwordHash,
+  passwordHint: passwordHint || '',
+  passwordLimit: passwordLimit ? parseInt(passwordLimit) : null,
+  failedAttempts: 0,
 
   createdAt: admin.firestore.FieldValue.serverTimestamp(),
   utmParams: parseUTMParams(finalUrl) || utmParams || {},
@@ -1922,6 +1935,121 @@ app.get('/:username/:slug', async (req, res) => {
   res.redirect(redirectUrl);
 });
 
+// Password protection: verify password
+app.post('/api/links/:shortCode/verify-password', async (req, res) => {
+  const { shortCode } = req.params;
+  const { password } = req.body;
+  
+  try {
+    const { link } = await resolveLinkForRedirect(shortCode);
+    
+    if (!link || !link.passwordHash) {
+      return res.status(404).json({ error: 'Link not found or not protected' });
+    }
+
+    if (link.passwordLimit && (link.failedAttempts || 0) >= link.passwordLimit) {
+      return res.status(403).json({ error: 'Too many failed attempts. Link is locked.' });
+    }
+
+    const matches = await bcrypt.compare(password || '', link.passwordHash);
+    if (!matches) {
+      const firestoreId = toFirestoreId(shortCode);
+      await db.collection(COLLECTIONS.LINKS).doc(firestoreId).update({
+        failedAttempts: admin.firestore.FieldValue.increment(1)
+      });
+      if (links.has(shortCode)) {
+        links.get(shortCode).failedAttempts = (link.failedAttempts || 0) + 1;
+      }
+      return res.status(401).json({ error: 'Incorrect password' });
+    }
+
+    // Success
+    let redirectUrl = link.originalUrl;
+    let variantLabel = null;
+
+    if (link.splitTest && Array.isArray(link.variants) && link.variants.length > 0) {
+      const selectedVariant = splitTestService.selectVariantByWeight(link.variants);
+      redirectUrl = selectedVariant.url;
+      variantLabel = selectedVariant.label;
+    }
+
+    // Track click analytics
+    trackClickAndEmit(shortCode, req, variantLabel).catch(err => {
+      console.error('Error tracking redirect click:', err);
+    });
+
+    return res.json({ url: redirectUrl });
+  } catch (error) {
+    console.error('Error verifying password:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// Password protection: get hint
+app.get('/api/links/:shortCode/protection', async (req, res) => {
+  const { shortCode } = req.params;
+  try {
+    const { link } = await resolveLinkForRedirect(shortCode);
+    if (!link || !link.passwordHash) {
+      return res.status(404).json({ error: 'Link not protected' });
+    }
+    return res.json({ 
+      hint: link.passwordHint || '',
+      locked: !!(link.passwordLimit && (link.failedAttempts || 0) >= link.passwordLimit)
+    });
+  } catch (error) {
+    console.error('Error getting protection info:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// Password protection: manage password
+app.put('/api/links/:shortCode/password', verifyToken, async (req, res) => {
+  const { shortCode } = req.params;
+  const { password, passwordHint, passwordLimit } = req.body;
+  const userId = req.user.uid;
+
+  try {
+    const firestoreId = toFirestoreId(shortCode);
+    const linkRef = db.collection(COLLECTIONS.LINKS).doc(firestoreId);
+    const linkDoc = await linkRef.get();
+
+    if (!linkDoc.exists) {
+      return res.status(404).json({ error: 'Link not found' });
+    }
+    
+    if (linkDoc.data().userId !== userId) {
+      return res.status(403).json({ error: 'Not authorized to modify this link' });
+    }
+
+    const updates = {};
+    if (password) {
+      updates.passwordHash = await bcrypt.hash(password, 10);
+      updates.passwordHint = passwordHint || '';
+      updates.passwordLimit = passwordLimit ? parseInt(passwordLimit) : null;
+      updates.failedAttempts = 0;
+    } else {
+      // Remove protection
+      updates.passwordHash = null;
+      updates.passwordHint = '';
+      updates.passwordLimit = null;
+      updates.failedAttempts = 0;
+    }
+
+    await linkRef.update(updates);
+    
+    if (links.has(shortCode)) {
+      const cachedLink = links.get(shortCode);
+      Object.assign(cachedLink, updates);
+    }
+
+    return res.json({ success: true });
+  } catch (error) {
+    console.error('Error updating password:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
 // Redirect short link and track click (also handles bio links)
 app.get('/:shortCode', async (req, res) => {
   const { shortCode } = req.params;
@@ -1938,6 +2066,11 @@ app.get('/:shortCode', async (req, res) => {
   
   if (!link) {
     return res.status(404).send('Link not found');
+  }
+
+  if (link.passwordHash) {
+    // Serve protected.html instead of redirecting
+    return res.sendFile(path.join(__dirname, 'public', 'protected.html'));
   }
 
   let redirectUrl = link.originalUrl;


### PR DESCRIPTION
Fixes #288

Backend half (1/2) of password-protected private links: hash/verify/manage endpoints in server.js, using bcryptjs (10 rounds) instead of unsalted SHA256 -- SHA256 alone is crackable via rainbow tables for any common password, defeating the point of a password-protection feature. Split from the frontend UI (separate PR) to keep this diff to one concern and under the file-count gate.

**Testing:** No automated test suite in this repo. Verified server.js parses (node --check) and bcryptjs loads correctly.

---

## Summary

Brief description of the changes.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code style / formatting
- [ ] Refactor
- [ ] Chore / maintenance

## Checklist

- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide
- [ ] My code follows the project's coding standards
- [ ] I have tested my changes locally
- [ ] I have linked related issues
- [ ] I have included screenshots for UI changes (if applicable)

## Notes

Any additional context or notes for reviewers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional password protection for shortened links.
  * Link owners can set, update, remove, and configure password attempt limits.
  * Protected links now display a password prompt before redirecting.
  * Added password hints and lock-status information.
  * Successful verification redirects visitors to the destination and preserves analytics and split-test behavior.
  * Links lock after the configured number of failed password attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->