### PR TITLE
bug: Custom short code availability is checked separately from cr...

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1155,10 +1155,14 @@ async function handleCreateLink() {
         
         if (!response.ok) {
             let errorMsg = 'Failed to create link';
-            try {
-                const errData = await response.json();
-                errorMsg = errData.error || errData.message || errorMsg;
-            } catch (_) {}
+            if (response.status === 409) {
+                errorMsg = 'That custom short code was just taken! Please try another one.';
+            } else {
+                try {
+                    const errData = await response.json();
+                    errorMsg = errData.error || errData.message || errorMsg;
+                } catch (_) {}
+            }
             showToast(errorMsg, 'error');
             return;
         }

--- a/server.js
+++ b/server.js
@@ -486,14 +486,20 @@ app.post('/api/shorten', verifyToken, async (req, res) => {
   try {
     // Convert shortCode to Firestore-safe ID (replace / with _)
     const firestoreId = toFirestoreId(shortCode);
+    const linkRef = db.collection(COLLECTIONS.LINKS).doc(firestoreId);
+    const analyticsRef = db.collection(COLLECTIONS.ANALYTICS).doc(firestoreId);
     
-    // Save to Firestore
-    console.log('Saving link to Firestore:', { shortCode, firestoreId, userId, linkData });
-    await db.collection(COLLECTIONS.LINKS).doc(firestoreId).set(linkData);
-    console.log('Link saved successfully to Firestore');
-    
-    await db.collection(COLLECTIONS.ANALYTICS).doc(firestoreId).set(analyticsData);
-    console.log('Analytics saved successfully to Firestore');
+    // Save to Firestore using a transaction to prevent TOCTOU race conditions
+    console.log('Saving link to Firestore via transaction:', { shortCode, firestoreId, userId, linkData });
+    await db.runTransaction(async (transaction) => {
+      const existingDoc = await transaction.get(linkRef);
+      if (existingDoc.exists) {
+        throw new Error('COLLISION');
+      }
+      transaction.set(linkRef, linkData);
+      transaction.set(analyticsRef, analyticsData);
+    });
+    console.log('Link saved successfully to Firestore via transaction');
     
     // Sync to Redis for edge redirects
     await redisUtils.storeLinkInRedis(shortCode, {
@@ -520,9 +526,15 @@ app.post('/api/shorten', verifyToken, async (req, res) => {
       isCustom: !!customShortCode
     });
   } catch (error) {
+    if (error.message === 'COLLISION') {
+      return res.status(409).json({ error: 'This custom short code is already taken' });
+    }
     console.error('Error saving to Firestore:', error);
     
-    // Fallback to in-memory storagehealthStatus
+    // Fallback to in-memory storage (with collision check)
+    if (links.has(shortCode)) {
+      return res.status(409).json({ error: 'This custom short code is already taken' });
+    }
     links.set(shortCode, linkData);
     analytics.set(shortCode, analyticsData);
     await redirectCache.set(shortCode, normalizeRedirectLink(linkData));


### PR DESCRIPTION
Fixes #275

Converted the two-step check-then-set custom short code creation logic in POST /api/shorten into an atomic Firestore Transaction. The transaction gets the custom link document and verifies it does not exist before writing both the link and analytics documents, preventing concurrent TOCTOU vanity URL takeovers. Updated frontend toast messaging to display a clear 'code was just taken' error message on 409 Conflict.

**Testing:** Ran eslint check, zero errors.

---

## Summary

Brief description of the changes.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code style / formatting
- [ ] Refactor
- [ ] Chore / maintenance

## Checklist

- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide
- [ ] My code follows the project's coding standards
- [ ] I have tested my changes locally
- [ ] I have linked related issues
- [ ] I have included screenshots for UI changes (if applicable)

## Notes

Any additional context or notes for reviewers.